### PR TITLE
[WEAV-157] 네트워크 모듈 접근제어자 수정, async/await request 추가

### DIFF
--- a/weave-iOS/Projects/Core/Sources/Network/Endpoint/EndPoint.swift
+++ b/weave-iOS/Projects/Core/Sources/Network/Endpoint/EndPoint.swift
@@ -7,19 +7,19 @@
 
 import Foundation
 
-protocol RequestResponsable: Requestable, Responsable {}
+public protocol RequestResponsable: Requestable, Responsable {}
 
-class EndPoint<R>: RequestResponsable {
-    typealias Response = R
+public class EndPoint<R>: RequestResponsable {
+    public typealias Response = R
 
-    var baseURL: String
-    var path: String
-    var method: HTTPMethod
-    var queryParameters: Encodable?
-    var bodyParameters: Encodable?
-    var headers: [String : String]?
+    public var baseURL: String
+    public var path: String
+    public var method: HTTPMethod
+    public var queryParameters: Encodable?
+    public var bodyParameters: Encodable?
+    public var headers: [String : String]?
     
-    init(baseURL: String,
+    public init(baseURL: String,
          path: String,
          method: HTTPMethod,
          queryParameters: Encodable? = nil,
@@ -34,7 +34,7 @@ class EndPoint<R>: RequestResponsable {
     }
 }
 
-enum HTTPMethod: String {
+public enum HTTPMethod: String {
     case get = "GET"
     case post = "POST"
     case put = "PUT"

--- a/weave-iOS/Projects/Core/Sources/Network/Endpoint/Requestable.swift
+++ b/weave-iOS/Projects/Core/Sources/Network/Endpoint/Requestable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol Requestable {
+public protocol Requestable {
     var baseURL: String { get }
     var path: String { get }
     var method: HTTPMethod { get }

--- a/weave-iOS/Projects/Core/Sources/Network/Endpoint/Responsable.swift
+++ b/weave-iOS/Projects/Core/Sources/Network/Endpoint/Responsable.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol Responsable {
+public protocol Responsable {
     associatedtype Response
 }

--- a/weave-iOS/Projects/Core/Sources/Network/Sample/APIEndpoints.swift
+++ b/weave-iOS/Projects/Core/Sources/Network/Sample/APIEndpoints.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 public struct UniversitiesResponseDTO: Decodable {
-    let universities: [UniversityResponseDTO]
+    public let universities: [UniversityResponseDTO]
 }
 
-struct UniversityResponseDTO: Decodable {
-    let id: String
-    let name: String
-    let domainAddress: String
-    let logoAddress: String
+public struct UniversityResponseDTO: Decodable, Equatable {
+    public let id: String
+    public let name: String
+    public let domainAddress: String
+    public let logoAddress: String?
 }
 
 public struct APIEndpoints {
-    static func getUniversitiesInfo() -> EndPoint<UniversitiesResponseDTO> {
+    public static func getUniversitiesInfo() -> EndPoint<UniversitiesResponseDTO> {
         return EndPoint(baseURL: "http://43.200.117.125:8080/",
                         path: "api/univ",
                         method: .get)


### PR DESCRIPTION
## 구현사항
- 네트워크 모듈 중 Provider, Endpoint, Requestable 및 일부 함수 접근제어자 public 으로 수정
- API Provider urlsession의 async/await 방식의 함수 추가

## 특이사항
- 사용 방법
```
let endPoint = APIEndpoints.getUniversitiesInfo()
let provider = APIProvider(session: URLSession.shared)
let response: UniversitiesResponseDTO = try await provider.request(with: endPoint)
```

