### PR TITLE
[WEAV-188] Weave 커스텀 Alert 구현

### DIFF
--- a/weave-iOS/Projects/DesignSystem/Sources/Alert/WeaveAlert.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/Alert/WeaveAlert.swift
@@ -1,0 +1,125 @@
+//
+//  WeaveAlert.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 2/10/24.
+//
+
+import SwiftUI
+
+public struct WeaveAlert: View {
+    
+    @Binding var isPresented: Bool
+    @State var animation: Bool = false
+    
+    @State private var backgroundOpacity = 0.0
+    @State private var zStackOffset = UIScreen.main.bounds.size.height / 2
+    
+    let title: String
+    var message: String?
+    let primaryButtonTitle: String
+    var secondaryButtonTitle: String?
+    var primaryAction: (() -> Void)?
+    var secondaryAction: (() -> Void)?
+    
+    init(
+        isPresented: Binding<Bool>,
+        title: String,
+        message: String? = nil,
+        primaryButtonTitle: String,
+        secondaryButtonTitle: String? = nil,
+        primaryAction: (() -> Void)? = nil,
+        secondaryAction: (() -> Void)? = nil
+    ) {
+        self._isPresented = isPresented
+        self.title = title
+        self.message = message
+        self.primaryButtonTitle = primaryButtonTitle
+        self.secondaryButtonTitle = secondaryButtonTitle
+        self.primaryAction = primaryAction
+        self.secondaryAction = secondaryAction
+    }
+    
+    private var viewWidth: CGFloat {
+        return UIScreen.main.bounds.size.width - 60
+    }
+    
+    public var body: some View {
+        ZStack {
+            DesignSystem.Colors.black.opacity(backgroundOpacity).ignoresSafeArea()
+            ZStack {
+                VStack(spacing: 0) {
+                    VStack(spacing: 16) {
+                        Text(title)
+                            .multilineTextAlignment(.center)
+                            .font(.pretendard(._600, size: 16))
+                            .lineSpacing(8)
+                        
+                        if let message {
+                            Text(message)
+                                .multilineTextAlignment(.center)
+                                .font(.pretendard(._400, size: 14))
+                                .lineSpacing(2)
+                        }
+                    }
+                    .padding(.top, 22)
+                    .padding(.bottom, 16)
+                    
+                    HStack(spacing: 8) {
+                        if let secondaryButtonTitle {
+                            WeaveButton(
+                                title: secondaryButtonTitle,
+                                backgroundColor: DesignSystem.Colors.lightGray
+                            ) {
+                                isPresented.toggle()
+                                secondaryAction?()
+                            }
+                            .frame(width: getButtonWidth(ratio: 0.3))
+                        }
+                        
+                        WeaveButton(title: primaryButtonTitle) {
+                            isPresented.toggle()
+                            primaryAction?()
+                        }
+                        .frame(width: getButtonWidth(ratio: 0.7))
+                    }
+                    .frame(width: viewWidth - 40)
+                    .padding(.vertical, 16)
+                }
+                .padding(.horizontal, 20)
+            }
+            .background(DesignSystem.Colors.darkGray)
+            .clipShape(
+                RoundedRectangle(cornerRadius: 14)
+            )
+            .frame(width: viewWidth)
+            .offset(y: zStackOffset)
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.15)) {
+                backgroundOpacity = 0.4
+            }
+            withAnimation(.spring(.bouncy(duration: 0.2))) {
+                zStackOffset = 0
+            }
+        }
+    }
+    
+    private func getButtonWidth(ratio: CGFloat) -> CGFloat {
+        let buttonStackWidth = viewWidth - 40 - 8
+        return buttonStackWidth * ratio
+    }
+}
+
+#Preview {
+    WeaveAlert(
+        isPresented: .constant(true),
+        title: "🚀\n학교 메일 인증",
+        message: "인증 메일이 발송되었어요.\n메일을 확인해 인증을 완료해 주세요.",
+        primaryButtonTitle: "확인",
+        secondaryButtonTitle: "취소",
+        primaryAction: {
+            print("엥")
+        }
+    )
+}

--- a/weave-iOS/Projects/DesignSystem/Sources/Alert/WeaveAlertExample.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/Alert/WeaveAlertExample.swift
@@ -1,0 +1,73 @@
+//
+//  WeaveAlertExample.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 2/10/24.
+//
+
+import SwiftUI
+
+struct WeaveAlertExample: View {
+    
+    @State var isMailAlertShow = false
+    @State var isOfflineCheckAlertShow = false
+    
+    var body: some View {
+        VStack {
+            Text("Alert 테스트 뷰")
+                .font(.pretendard(._800, size: 35))
+            Spacer()
+            
+            HStack(spacing: 15) {
+                WeaveButton(
+                    title: "메일 인증",
+                    style: .filled,
+                    size: .medium) {
+                        isMailAlertShow.toggle()
+                    }
+                    .frame(width: 150)
+                    .weaveAlert(
+                        isPresented: $isMailAlertShow,
+                        title: "🚀\n학교 메일 인증",
+                        message: "인증 메일이 발송되었어요.\n메일을 확인해 인증을 완료해 주세요.",
+                        primaryButtonTitle: "확인",
+                        secondaryButtonTitle: "취소",
+                        primaryAction: {
+                            print("확인 버튼 액션")
+                        },
+                        secondaryAction: {
+                            print("취소 버튼 액션")
+                        }
+                    )
+                
+                WeaveButton(
+                    title: "로그아웃",
+                    style: .filled,
+                    size: .medium) {
+                        print("탭!")
+                        isOfflineCheckAlertShow.toggle()
+                    }
+                    .frame(width: 150)
+                    .weaveAlert(
+                        isPresented: $isOfflineCheckAlertShow,
+                        title: "로그아웃 하시겠어요?",
+                        primaryButtonTitle: "네, 할래요",
+                        secondaryButtonTitle: "아니요",
+                        primaryAction: {
+                            print("로그아웃 액션")
+                        },
+                        secondaryAction: {
+                            print("취소 버튼 액션")
+                        }
+                    )
+                
+            }
+            Spacer()
+                .frame(height: 250)
+        }
+    }
+}
+
+#Preview {
+    WeaveAlertExample()
+}

--- a/weave-iOS/Projects/DesignSystem/Sources/Alert/WeaveAlertModifier.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/Alert/WeaveAlertModifier.swift
@@ -1,0 +1,50 @@
+//
+//  WeaveAlertModifier.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 2/10/24.
+//
+
+import SwiftUI
+
+public struct WeaveAlertModifier: ViewModifier {
+    
+    @Binding var isPresented: Bool
+    
+    let weaveAlert: WeaveAlert
+    
+    public func body(content: Content) -> some View {
+        content
+            .transparentFullScreenCover(isPresented: $isPresented) {
+                weaveAlert
+            }
+            .transaction({ transaction in
+                transaction.disablesAnimations = true
+//                transaction.animation = .linear(duration: 0.5)
+            })
+    }
+}
+
+public extension View {
+    func weaveAlert(
+        isPresented: Binding<Bool>,
+        title: String,
+        message: String? = nil,
+        primaryButtonTitle: String,
+        secondaryButtonTitle: String? = nil,
+        primaryAction: (() -> Void)? = nil,
+        secondaryAction: (() -> Void)? = nil
+    ) -> some View {
+        let alert = WeaveAlert(
+            isPresented: isPresented,
+            title: title,
+            message: message,
+            primaryButtonTitle: primaryButtonTitle,
+            secondaryButtonTitle: secondaryButtonTitle,
+            primaryAction: primaryAction,
+            secondaryAction: secondaryAction
+        )
+        return modifier(WeaveAlertModifier(isPresented: isPresented, weaveAlert: alert))
+    }
+}
+

--- a/weave-iOS/Projects/DesignSystem/Sources/Button/WeaveButton.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/Button/WeaveButton.swift
@@ -13,6 +13,8 @@ public struct WeaveButton: View {
     let isEnabled: Bool
     let style: WeaveButtonStyle
     let size: ButtonSize
+    let textColor: Color
+    let buttonBackgroundColor: Color
     var icon: Image?
     var handler: (() -> Void)?
     @State private var isTouched: Bool = false
@@ -27,7 +29,7 @@ public struct WeaveButton: View {
     }
     
     var buttonTintColor: Color {
-        return isTouched ? DesignSystem.Colors.gray500 : DesignSystem.Colors.defaultBlue
+        return isTouched ? DesignSystem.Colors.gray500 : buttonBackgroundColor
     }
     
     public init(
@@ -35,6 +37,8 @@ public struct WeaveButton: View {
         icon: Image? = nil,
         style: WeaveButtonStyle = .filled,
         size: ButtonSize = .regular,
+        textColor: Color = DesignSystem.Colors.white,
+        backgroundColor: Color = DesignSystem.Colors.defaultBlue,
         isEnabled: Bool = true,
         handler: (() -> Void)? = nil
     ) {
@@ -42,6 +46,8 @@ public struct WeaveButton: View {
         self.icon = icon
         self.style = style
         self.size = size
+        self.textColor = textColor
+        self.buttonBackgroundColor = backgroundColor
         self.isEnabled = isEnabled
         self.handler = handler
     }

--- a/weave-iOS/Projects/DesignSystem/Sources/Button/WeaveButton.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/Button/WeaveButton.swift
@@ -27,10 +27,7 @@ public struct WeaveButton: View {
     }
     
     var buttonTintColor: Color {
-        if !isEnabled {
-            return DesignSystem.Colors.gray200
-        }
-        return isTouched ? DesignSystem.Colors.gray500 : DesignSystem.Colors.defaultPurple
+        return isTouched ? DesignSystem.Colors.gray500 : DesignSystem.Colors.defaultBlue
     }
     
     public init(
@@ -66,13 +63,19 @@ public struct WeaveButton: View {
                 Spacer()
             }
             .background(backgroundColor)
-            .cornerRadius(8)
+            .clipShape(Capsule())
             .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(
-                        foregroundColor,
-                        lineWidth: style == .outline ? 1 : 0
-                    )
+                ZStack {
+                    Capsule()
+                        .stroke(
+                            foregroundColor,
+                            lineWidth: style == .outline ? 1 : 0
+                        )
+                    if !isEnabled {
+                        Capsule()
+                            .foregroundStyle(.black.opacity(0.25))
+                    }
+                }
             )
             .gesture(
                 DragGesture(minimumDistance: 0)
@@ -86,6 +89,7 @@ public struct WeaveButton: View {
             )
             .disabled(!isEnabled)
         }
+        .animation(.easeInOut(duration: 0.1), value: isTouched)
     }
 }
 

--- a/weave-iOS/Projects/DesignSystem/Sources/TransparentBackground/TransparentBackground.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/TransparentBackground/TransparentBackground.swift
@@ -1,0 +1,43 @@
+//
+//  TransparentBackground.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 2/10/24.
+//
+
+import SwiftUI
+
+fileprivate struct TransparentBackground: UIViewRepresentable {
+    
+    fileprivate func makeUIView(context: Context) -> UIView {
+        
+        let view = TransparentBackgroundView()
+        DispatchQueue.main.async {
+            view.superview?.superview?.backgroundColor = .clear
+        }
+        return view
+    }
+
+    fileprivate func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+private class TransparentBackgroundView: UIView {
+    open override func layoutSubviews() {
+        guard let parentView = superview?.superview else {
+            return
+        }
+        parentView.backgroundColor = .clear
+    }
+}
+
+public extension View {
+    /// 투명 배경으로 FullScreenCover를 show 합니다.
+    func transparentFullScreenCover<Content: View>(isPresented: Binding<Bool>, content: @escaping () -> Content) -> some View {
+        fullScreenCover(isPresented: isPresented) {
+            ZStack {
+                content()
+            }
+            .background(TransparentBackground())
+        }
+    }
+}


### PR DESCRIPTION
## 구현사항
- 커스텀 Alert 구현
- Alert Example 코드 구현

## 특이사항
- [투명한 FullScreenCover를 위해 TransparentBackground 구현 및 적용](https://www.notion.so/student-center/FullScreenCover-73520ba32fd34b09ae1e3a4acfe66375?pvs=4)
- Alert 생성시 애니메이션 따로 요구받은 것이 없어 임의로 아래-위 Spring Bounce 로 적용했습니다. 이부분은 디자이너님과 얘기해볼께요

## 고민(선택)
- Alert을 생성할 때 Action Button을 배열로 받아서 처리할까 생각했는데(버튼 갯수 제한 없도록) 
  1. 버튼 갯수가 많아진 경우의 레이아웃 대응 필요
  2. 현 기획 상으로 요구되는 버튼 갯수는 2개가 최대임
  - 위 이유로 1-2개로 고정했습니다. 요구되는 버튼 갯수가 많아진다면 리팩토링을 고려해 볼께요

## 스크린샷(선택)
|버튼이 하나일 때/메시지O|버튼이 두개일 때/메시지X|
|:---:|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/66df19d8-81c5-4ed4-b87f-f1c305320f06" width="400">|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/5d1953b1-0b19-4425-9b10-0207e0e77f52" width="400">