### PR TITLE
[WEAV-157] URLSession async await request 이슈 수정

### DIFF
--- a/weave-iOS/Projects/Core/Sources/Network/Provider/Provider.swift
+++ b/weave-iOS/Projects/Core/Sources/Network/Provider/Provider.swift
@@ -52,9 +52,9 @@ public class APIProvider {
     
     public func request<R: Decodable, E: RequestResponsable>(with endPoint: E) async throws -> R where E.Response == R {
         do {
-            guard let url = try endPoint.getUrlRequest().url else { throw NetworkError.components }
+            let url = try endPoint.getUrlRequest()
             
-            let (data, urlResponse) = try await session.data(from: url)
+            let (data, urlResponse) = try await session.data(for: url)
             
             guard let response = urlResponse as? HTTPURLResponse,
                   (200...399).contains(response.statusCode) else {

--- a/weave-iOS/Projects/Core/Sources/Network/Provider/Provider.swift
+++ b/weave-iOS/Projects/Core/Sources/Network/Provider/Provider.swift
@@ -52,9 +52,9 @@ public class APIProvider {
     
     public func request<R: Decodable, E: RequestResponsable>(with endPoint: E) async throws -> R where E.Response == R {
         do {
-            let url = try endPoint.getUrlRequest()
+            let urlRequest = try endPoint.getUrlRequest()
             
-            let (data, urlResponse) = try await session.data(for: url)
+            let (data, urlResponse) = try await session.data(for: urlRequest)
             
             guard let response = urlResponse as? HTTPURLResponse,
                   (200...399).contains(response.statusCode) else {


### PR DESCRIPTION
## 구현사항
- #6 이슈 수정
- async await request 함수에서 `URLReequst`가 아닌 `URL`만 가지고 dataTask 실행했음(header가 안들어감)
- Endpoint의 URLRequest 객체를 통해 요청되도록 수정함

## 특이사항
- 없음
