### PR TITLE
[Infra] Core, DesignSystem 모듈 Deployment Target Version 추가

### DIFF
--- a/weave-iOS/Projects/Core/Project.swift
+++ b/weave-iOS/Projects/Core/Project.swift
@@ -5,6 +5,9 @@ let target = Target(
     platform: .iOS,
     product: .staticFramework,
     bundleId: "com.studentcenter.weaveios.services",
+    deploymentTarget: .iOS(targetVersion: "17.0",
+                           devices: .iphone,
+                           supportsMacDesignedForIOS: false),
     sources: ["Sources/**"],
     dependencies: []
 )

--- a/weave-iOS/Projects/DesignSystem/Project.swift
+++ b/weave-iOS/Projects/DesignSystem/Project.swift
@@ -5,6 +5,9 @@ let target = Target(
     platform: .iOS,
     product: .framework,
     bundleId: "com.studentcenter.weaveios.designSystem",
+    deploymentTarget: .iOS(targetVersion: "17.0",
+                           devices: .iphone,
+                           supportsMacDesignedForIOS: false),
     sources: ["Sources/**"],
     resources: ["Resources/**"],
     dependencies: []


### PR DESCRIPTION
## 구현사항
- App의 Deployment Target - iOS 17.0 으로 변경에 따른 Core와 DesignSystem 모듈의 Deployment Target 도 동일하게 변경합니다.

## 특이사항
- 없습니다.