### PR TITLE
[FEAT] 회원가입 뷰 인터페이스 구현

### DIFF
--- a/weave-iOS/Projects/App/Sources/SignUp/View/SignUpView.swift
+++ b/weave-iOS/Projects/App/Sources/SignUp/View/SignUpView.swift
@@ -81,7 +81,7 @@ struct SignUpView: View {
 #Preview {
     SignUpView(
         store: Store(
-            initialState: SignUpFeature.State()) {
+            initialState: SignUpFeature.State(registerToken: "token")) {
                 SignUpFeature()
             }
     )


### PR DESCRIPTION
## 구현사항
- 로그인 이후 회원가입 뷰 전환을 위한 RegisterToken 인터페이스 구현

## 특이사항
- SignUp Reducer 내 State에 initialize 함수로 registerToken을 넣어줍니다.
```
    SignUpView(
        store: Store(
            initialState: SignUpFeature.State(registerToken: "token")) {
                SignUpFeature()
            }
    )
```