### PR TITLE
[WEAV-249] 로그인, 홈 분기 및 탭뷰 목업뷰 추가

### DIFF
--- a/weave-iOS/Projects/App/Sources/Chat/ChatView.swift
+++ b/weave-iOS/Projects/App/Sources/Chat/ChatView.swift
@@ -1,0 +1,18 @@
+//
+//  ChatView.swift
+//  weave-ios
+//
+//  Created by 강동영 on 2/21/24.
+//
+
+import SwiftUI
+
+struct ChatView: View {
+    var body: some View {
+        Text("Hello, ChatView!")
+    }
+}
+
+#Preview {
+    ChatView()
+}

--- a/weave-iOS/Projects/App/Sources/ContentView.swift
+++ b/weave-iOS/Projects/App/Sources/ContentView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 struct ContentView: View {
     @State private var selection: AppScreen? = .home
     var body: some View {
-        AppTabView(selection: $selection)
+        if UDManager.isLogin {
+            AppTabView(selection: $selection)
+        } else {
+            LoginView()
+        }
     }
 }
 

--- a/weave-iOS/Projects/App/Sources/Home/HomeView.swift
+++ b/weave-iOS/Projects/App/Sources/Home/HomeView.swift
@@ -1,0 +1,18 @@
+//
+//  HomeView.swift
+//  weave-ios
+//
+//  Created by 강동영 on 2/21/24.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("Hello, HomeView!")
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/weave-iOS/Projects/App/Sources/MyTeam/MyTeamView.swift
+++ b/weave-iOS/Projects/App/Sources/MyTeam/MyTeamView.swift
@@ -1,0 +1,18 @@
+//
+//  MyTeamView.swift
+//  weave-ios
+//
+//  Created by 강동영 on 2/21/24.
+//
+
+import SwiftUI
+
+struct MyTeamView: View {
+    var body: some View {
+        Text("Hello, MyTeam!")
+    }
+}
+
+#Preview {
+    MyTeamView()
+}

--- a/weave-iOS/Projects/App/Sources/Navigation/AppScreen.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/AppScreen.swift
@@ -56,13 +56,13 @@ extension AppScreen {
     var destination: some View {
         switch self {
         case .chat:
-            LoginView()
+            ChatView()
         case .home:
-            LoginView()
+            HomeView()
         case .request:
-            LoginView()
+            RequestView()
         case .myTeam:
-            LoginView()
+            MyTeamView()
         case .myPage:
             MyPageView(store: Store(initialState: MyPageFeature.State(), reducer: {
                 MyPageFeature()

--- a/weave-iOS/Projects/App/Sources/Request/RequestView.swift
+++ b/weave-iOS/Projects/App/Sources/Request/RequestView.swift
@@ -1,0 +1,18 @@
+//
+//  RequestView.swift
+//  weave-ios
+//
+//  Created by 강동영 on 2/21/24.
+//
+
+import SwiftUI
+
+struct RequestView: View {
+    var body: some View {
+        Text("Hello, Request!")
+    }
+}
+
+#Preview {
+    RequestView()
+}

--- a/weave-iOS/Projects/App/Sources/UDManager.swift
+++ b/weave-iOS/Projects/App/Sources/UDManager.swift
@@ -30,3 +30,11 @@ public enum UDManager {
     @UDWrapper(key: CommonKey.RefreshToken, defaultValue: "")
     static var refreshToken: String
 }
+
+extension UDManager {
+    static var isLogin: Bool {
+        print("accessToken: \(UDManager.accessToken)")
+        print("refreshToken: \(UDManager.refreshToken)")
+        return !UDManager.accessToken.isEmpty && !UDManager.refreshToken.isEmpty
+    }
+}

--- a/weave-iOS/Projects/App/Sources/WeaveApp.swift
+++ b/weave-iOS/Projects/App/Sources/WeaveApp.swift
@@ -20,7 +20,8 @@ struct WeaveApp: App {
     
     var body: some Scene {
         WindowGroup {
-            LoginView().onOpenURL(perform: { url in
+            ContentView()
+                .onOpenURL(perform: { url in
                 if (AuthApi.isKakaoTalkLoginUrl(url)) {
                     _ = AuthController.handleOpenUrl(url: url)
                 }


### PR DESCRIPTION
## 구현사항
- accessToekn, refreshToken 값을 가지고 `UDManager.isLogin`  을 통해 LoginView or AppTabView 분기처리를 하고있습니다.
- AppTabView에 Mock View를 위치해뒀습니다.

## 특이사항
- 없습니다.

## 고민(선택)
- 제 피처범위를 넘어서 작업할까봐 걱정을 하면서 플젝진행을 하고있는거같아요
그러다보니 조금 소극적인 부분이 있었던거같은데 우선은 제 판단대로 조금 더 적극적으로 작업해볼게요 !
문제사항이 있을 떄 한번 노티 부탁드려도 될까요 ㅎㅎ?


## 스크린샷(선택)
|디렉토리 구성|
|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/50406861/028c121a-1502-4a40-938c-0866b8ac840b" width="400">|
