### PR TITLE
[FIX] MBTI 재사용 가능한 형태 리팩토링

### DIFF
--- a/weave-iOS/Projects/App/Sources/SignUp/Feature/SignUpFeature.swift
+++ b/weave-iOS/Projects/App/Sources/SignUp/Feature/SignUpFeature.swift
@@ -93,14 +93,13 @@ struct SignUpFeature: Reducer {
                 } else {
                     // Validation
                     guard let gender = state.selectedGender,
-                          let mbti = state.mbtiDatas.value,
                           let birthYear = Int(state.birthYear),
                           let univ = state.selectedUniversity,
                           let major = state.selectedmajor else { return .none }
                     let requestDTO = RegisterUserRequestDTO(
                         gender: gender.value,
                         birthYear: birthYear,
-                        mbti: mbti,
+                        mbti: state.mbtiDatas.requestValue,
                         universityId: univ.id,
                         majorId: major.id
                     )
@@ -265,27 +264,6 @@ extension SignUpFeature {
             case .boy: return isSelected ? DesignSystem.Icons.boySelected : DesignSystem.Icons.boyNormal
             case .girl: return isSelected ? DesignSystem.Icons.girlSelected : DesignSystem.Icons.girlNormal
             }
-        }
-    }
-
-    struct MBTIDataModel: Equatable {
-        var EorI: String?
-        var NorS: String?
-        var ForT: String?
-        var PorJ: String?
-        
-        var value: String? {
-            guard let EorI,
-                  let NorS,
-                  let ForT,
-                  let PorJ else { return nil }
-            
-            return EorI + NorS + ForT + PorJ
-        }
-        
-        func validate() -> Bool {
-            return [EorI, NorS, ForT, PorJ]
-                .allSatisfy { $0 != nil }
         }
     }
 }

--- a/weave-iOS/Projects/App/Sources/SignUp/View/StepSubViews/SignUpMBTIView.swift
+++ b/weave-iOS/Projects/App/Sources/SignUp/View/StepSubViews/SignUpMBTIView.swift
@@ -16,40 +16,14 @@ struct SignUpMBTIView: View {
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             VStack {
-                HorizonCirclePicker(
-                    selectedData: viewStore.$mbtiDatas.EorI,
-                    dataSources: ["E", "e", "i", "I"],
-                    leadingText: "외향적",
-                    trailingText: "내향적"
-                )
-                
-                HorizonCirclePicker(
-                    selectedData: viewStore.$mbtiDatas.NorS,
-                    dataSources: ["N", "n", "s", "S"],
-                    leadingText: "직관적",
-                    trailingText: "현실적"
-                )
-                
-                HorizonCirclePicker(
-                    selectedData: viewStore.$mbtiDatas.ForT,
-                    dataSources: ["F", "f", "t", "T"],
-                    leadingText: "감성적",
-                    trailingText: "이성적"
-                )
-                
-                HorizonCirclePicker(
-                    selectedData: viewStore.$mbtiDatas.PorJ,
-                    dataSources: ["P", "p", "j", "J"],
-                    leadingText: "즉흥적",
-                    trailingText: "계획적"
-                )
+                MBTIPickerView(model: viewStore.$mbtiDatas)
                 
                 Spacer()
                 
                 WeaveButton(
                     title: "다음으로",
                     size: .medium,
-                    isEnabled: viewStore.mbtiDatas.validate()
+                    isEnabled: getButtonConfig(model: viewStore.mbtiDatas)
                 ) {
                     viewStore.send(
                         .didTappedNextButton,
@@ -60,70 +34,9 @@ struct SignUpMBTIView: View {
             }
         }
     }
-}
-
-fileprivate struct HorizonCirclePicker: View {
     
-    @Binding var selectedData: String?
-    
-    let dataSources: [String]
-    let leadingText: String
-    let trailingText: String
-    
-    fileprivate var body: some View {
-        VStack(spacing: 11) {
-            ZStack {
-                Rectangle()
-                    .frame(height: 1)
-                    .foregroundStyle(DesignSystem.Colors.lightGray)
-                HStack {
-                    ForEach(0 ..< dataSources.count, id: \.self) { index in
-                        
-                        // 큰 사이즈 조건
-                        let needLargeSize = (index == 0) || (index == dataSources.count - 1)
-                        let size: CGFloat = needLargeSize ? 53 : 37
-                        
-                        let data = dataSources[index]
-                        let isSelected = data == selectedData
-                        
-                        let tintColor = isSelected ? DesignSystem.Colors.defaultBlue : DesignSystem.Colors.lightGray
-                        
-                        ZStack {
-                            Circle()
-                                .foregroundStyle(DesignSystem.Colors.darkGray)
-                                .frame(width: size, height: size)
-                            Text(data)
-                                .foregroundStyle(tintColor)
-                                .font(.pretendard(._400, size: needLargeSize ? 28 : 20))
-                        }
-                        .overlay(
-                            Circle()
-                                .stroke(
-                                    tintColor,
-                                    lineWidth: 1
-                                )
-                                .foregroundStyle(.clear)
-                        )
-                        .onTapGesture {
-                            selectedData = data
-                        }
-                        
-                        // 마지막 Index 인 경우
-                        if index != dataSources.count - 1 {
-                            Spacer()
-                        }
-                    }
-                }
-            }
-            
-            HStack {
-                Text(leadingText)
-                Spacer()
-                Text(trailingText)
-            }
-            .font(.pretendard(._500, size: 16))
-            .padding(.horizontal, 5)
-        }
-        .padding(.vertical, 8)
+    func getButtonConfig(model: MBTIDataModel) -> Bool {
+        print(model)
+        return model.validate()
     }
 }

--- a/weave-iOS/Projects/App/Sources/SignUp/View/StepSubViews/SignUpMBTIView.swift
+++ b/weave-iOS/Projects/App/Sources/SignUp/View/StepSubViews/SignUpMBTIView.swift
@@ -23,7 +23,7 @@ struct SignUpMBTIView: View {
                 WeaveButton(
                     title: "다음으로",
                     size: .medium,
-                    isEnabled: getButtonConfig(model: viewStore.mbtiDatas)
+                    isEnabled: viewStore.mbtiDatas.validate()
                 ) {
                     viewStore.send(
                         .didTappedNextButton,
@@ -33,10 +33,5 @@ struct SignUpMBTIView: View {
                 .padding(.bottom, 20)
             }
         }
-    }
-    
-    func getButtonConfig(model: MBTIDataModel) -> Bool {
-        print(model)
-        return model.validate()
     }
 }

--- a/weave-iOS/Projects/DesignSystem/Sources/MBTIPicker/MBTIDataModel.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/MBTIPicker/MBTIDataModel.swift
@@ -1,0 +1,61 @@
+//
+//  MBTIDataModel.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 2/26/24.
+//
+
+import SwiftUI
+
+public struct MBTIDataModel: Equatable {
+    public static func == (lhs: MBTIDataModel, rhs: MBTIDataModel) -> Bool {
+        return lhs.requestValue == rhs.requestValue
+    }
+    
+    public enum MBTITypes: String {
+        case E
+        case e
+        case I
+        case i
+        case N
+        case n
+        case S
+        case s
+        case F
+        case f
+        case T
+        case t
+        case P
+        case p
+        case J
+        case j
+        case none
+    }
+    
+    public var 외향내향: MBTITypes
+    public var 감각직관: MBTITypes
+    public var 사고감정: MBTITypes
+    public var 판단인식: MBTITypes
+    
+    public init(
+        외향내향: MBTITypes = .none,
+        감각직관: MBTITypes = .none,
+        사고감정: MBTITypes = .none,
+        판단인식: MBTITypes = .none
+    ) {
+        self.외향내향 = 외향내향
+        self.감각직관 = 감각직관
+        self.사고감정 = 사고감정
+        self.판단인식 = 판단인식
+    }
+    
+    public var requestValue: String {
+        return [외향내향, 감각직관, 사고감정, 판단인식]
+            .map { $0.rawValue }
+            .joined()
+    }
+    
+    public func validate() -> Bool {
+        return [외향내향, 감각직관, 사고감정, 판단인식].allSatisfy { $0 != .none }
+    }
+}

--- a/weave-iOS/Projects/DesignSystem/Sources/MBTIPicker/MBTIPickerView.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/MBTIPicker/MBTIPickerView.swift
@@ -1,0 +1,114 @@
+//
+//  MBTIPickerView.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 2/26/24.
+//
+
+import SwiftUI
+
+public struct MBTIPickerView: View {
+    
+    @Binding var mbtiDataModel: MBTIDataModel
+    
+    public init(model: Binding<MBTIDataModel>) {
+        self._mbtiDataModel = model
+    }
+    
+    public var body: some View {
+        VStack {
+            HorizonCirclePicker(
+                dataSources: [.E, .e, .i, .I],
+                leadingText: "외향적",
+                trailingText: "내향적",
+                selectedData: $mbtiDataModel.외향내향
+            )
+            
+            HorizonCirclePicker(
+                dataSources: [.N, .n, .s, .S],
+                leadingText: "직관적",
+                trailingText: "현실적",
+                selectedData: $mbtiDataModel.감각직관
+            )
+            
+            HorizonCirclePicker(
+                dataSources: [.F, .f, .t, .T],
+                leadingText: "감성적",
+                trailingText: "이성적",
+                selectedData: $mbtiDataModel.사고감정
+            )
+            
+            HorizonCirclePicker(
+                dataSources: [.P, .p, .j, .J],
+                leadingText: "즉흥적",
+                trailingText: "계획적",
+                selectedData: $mbtiDataModel.판단인식
+            )
+        }
+    }
+}
+
+fileprivate struct HorizonCirclePicker: View {
+        
+    let dataSources: [MBTIDataModel.MBTITypes]
+    let leadingText: String
+    let trailingText: String
+    @Binding var selectedData: MBTIDataModel.MBTITypes
+    
+    fileprivate var body: some View {
+        VStack(spacing: 11) {
+            ZStack {
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundStyle(DesignSystem.Colors.lightGray)
+                HStack {
+                    ForEach(0 ..< dataSources.count, id: \.self) { index in
+                        
+                        // 큰 사이즈 조건
+                        let needLargeSize = (index == 0) || (index == dataSources.count - 1)
+                        let size: CGFloat = needLargeSize ? 53 : 37
+                        
+                        let mbti = dataSources[index]
+                        let isSelected = mbti == selectedData
+                        
+                        let tintColor = isSelected ? DesignSystem.Colors.defaultBlue : DesignSystem.Colors.lightGray
+                        
+                        ZStack {
+                            Circle()
+                                .foregroundStyle(DesignSystem.Colors.darkGray)
+                                .frame(width: size, height: size)
+                            Text(mbti.rawValue)
+                                .foregroundStyle(tintColor)
+                                .font(.pretendard(._400, size: needLargeSize ? 28 : 20))
+                        }
+                        .overlay(
+                            Circle()
+                                .stroke(
+                                    tintColor,
+                                    lineWidth: 1
+                                )
+                                .foregroundStyle(.clear)
+                        )
+                        .onTapGesture {
+                            selectedData = mbti
+                        }
+                        
+                        // 마지막 Index 인 경우
+                        if index != dataSources.count - 1 {
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            
+            HStack {
+                Text(leadingText)
+                Spacer()
+                Text(trailingText)
+            }
+            .font(.pretendard(._500, size: 16))
+            .padding(.horizontal, 5)
+        }
+        .padding(.vertical, 8)
+    }
+}


### PR DESCRIPTION
## 구현사항
- 기존 회원가입 뷰에서 구현했던 MBTI Picker View를 리팩토링
- 마이페이지 - MBTI 수정에서도 동일한 Picker 를 사용하는 관계로 수정작업 진행
- 기존 String 형태의 데이터 -> 각 element들을 enum 으로 관리하는 형태
- MBTIPickerView 로 Wrapping

## 특이사항
- 사용 예시
```
// View
var body: some View {
  WithViewStore(store, observe: { $0 }) { viewStore in
    MBTIPickerView(model: viewStore.$mbtiDatas)
}

// Reducer.State
struct State: Equatable {
  @BindingState var mbtiDatas = MBTIDataModel()
}
```
