### PR TITLE
[FEAT] 학교 메일 인증 뷰 destination 구조 연결

### DIFF
--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
@@ -18,6 +18,8 @@ struct MyPageFeature: Reducer {
         @BindingState var isShowCamera: Bool = false
         @BindingState var isShowCameraPermissionAlert: Bool = false
         
+        @BindingState var isShowCompleteUnivVerifyAlert: Bool = false
+        
         @PresentationState var destination: Destination.State?
     }
     
@@ -93,8 +95,11 @@ struct MyPageFeature: Reducer {
                             selectedAnimal: animalType
                         )
                     )
+                case .emailVerification:
+                    state.destination = .univVerify(.init(universityName: state.myUserInfo?.universityName ?? ""))
                 default: break
                 }
+                
                 return .none
                 
             case .destination(.dismiss):
@@ -102,6 +107,11 @@ struct MyPageFeature: Reducer {
                 return .run { send in
                     await send.callAsFunction(.requestMyUserInfo)
                 }
+                
+            case .destination(.presented(.univVerify(.didCompleteVerifyEmail))):
+                state.destination = nil
+                state.isShowCompleteUnivVerifyAlert.toggle()
+                return .none
                 
             case .showPhotoPicker:
                 state.isShowPhotoPicker.toggle()
@@ -175,11 +185,13 @@ extension MyPageFeature {
             case editMbti(MyMbtiEditFeature.State)
             case editAnimal(MyAnimalSelectionFeature.State)
             case editHeight(MyHeightEditFeature.State)
+            case univVerify(UnivEmailInputFeature.State)
         }
         enum Action {
             case editMbti(MyMbtiEditFeature.Action)
             case editAnimal(MyAnimalSelectionFeature.Action)
             case editHeight(MyHeightEditFeature.Action)
+            case univVerify(UnivEmailInputFeature.Action)
         }
         var body: some ReducerOf<Self> {
             Scope(state: /State.editMbti, action: /Action.editMbti) {
@@ -190,6 +202,9 @@ extension MyPageFeature {
             }
             Scope(state: /State.editHeight, action: /Action.editHeight) {
                 MyHeightEditFeature()
+            }
+            Scope(state: /State.univVerify, action: /Action.univVerify) {
+                UnivEmailInputFeature()
             }
         }
     }

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
@@ -19,6 +19,7 @@ struct MyPageFeature: Reducer {
         @BindingState var isShowCameraPermissionAlert: Bool = false
         
         @BindingState var isShowCompleteUnivVerifyAlert: Bool = false
+        @BindingState var isShowCompleteUnivVerifyView: Bool = false
         
         @PresentationState var destination: Destination.State?
     }
@@ -96,7 +97,12 @@ struct MyPageFeature: Reducer {
                         )
                     )
                 case .emailVerification:
+                    if state.myUserInfo?.isUniversityEmailVerified == true {
+                        state.isShowCompleteUnivVerifyView.toggle()
+                        return .none
+                    }
                     state.destination = .univVerify(.init(universityName: state.myUserInfo?.universityName ?? ""))
+                    
                 default: break
                 }
                 

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/View/MyPageView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/View/MyPageView.swift
@@ -49,6 +49,9 @@ struct MyPageView: View {
                         .padding(.horizontal, 16)
                     }
                 }
+                .navigationDestination(isPresented: viewStore.$isShowCompleteUnivVerifyView, destination: {
+                    UnivEmailCompleteView()
+                })
                 .weaveAlert(
                     isPresented: viewStore.$isShowCompleteUnivVerifyAlert,
                     title: "✅\n대학교 인증 완료!",

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/View/MyPageView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/View/MyPageView.swift
@@ -49,6 +49,16 @@ struct MyPageView: View {
                         .padding(.horizontal, 16)
                     }
                 }
+                .weaveAlert(
+                    isPresented: viewStore.$isShowCompleteUnivVerifyAlert,
+                    title: "✅\n대학교 인증 완료!",
+                    message: "이제 내 팀을 만들 수 있어요.\n지금 바로 내 팀을 만들러 가볼까요?",
+                    primaryButtonTitle: "네, 좋아요",
+                    secondaryButtonTitle: "나중에",
+                    primaryAction: {
+                        
+                    }
+                )
                 .onAppear {
                     viewStore.send(.requestMyUserInfo)
                 }
@@ -68,6 +78,14 @@ struct MyPageView: View {
                         .foregroundStyle(.white)
                     }
                 })
+            }
+            // 대학교 인증
+            .navigationDestination(
+                store: self.store.scope(state: \.$destination, action: { .destination($0) }),
+                state: /MyPageFeature.Destination.State.univVerify,
+                action: MyPageFeature.Destination.Action.univVerify
+            ) { store in
+                UnivEmailInputView(store: store)
             }
             // MBTI
             .sheet(

--- a/weave-iOS/Projects/App/Sources/MyPage/UnivVerification/View/UnivEmailCompleteView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/UnivVerification/View/UnivEmailCompleteView.swift
@@ -1,0 +1,37 @@
+//
+//  UnivEmailCompleteView.swift
+//  weave-ios
+//
+//  Created by Jisu Kim on 3/18/24.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct UnivEmailCompleteView: View {
+    @Environment(\.dismiss) var dismiss
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            DesignSystem.Icons.certified
+                .resizable()
+                .frame(width: 36, height: 36)
+            Text("학교 메일 인증 완료!")
+                .font(.pretendard(._500, size: 22))
+        }
+        .offset(y: -50)
+        .navigationTitle("대학교 인증")
+        .navigationBarBackButtonHidden()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .foregroundStyle(.white)
+            }
+        }
+    }
+}

--- a/weave-iOS/Projects/App/Sources/MyPage/UnivVerification/View/UnivEmailInputView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/UnivVerification/View/UnivEmailInputView.swift
@@ -15,83 +15,79 @@ struct UnivEmailInputView: View {
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-            NavigationStack {
-                VStack {
-                    Spacer()
-                        .frame(height: 38)
+            VStack {
+                Spacer()
+                    .frame(height: 38)
+                
+                VStack(spacing: 12) {
+                    Text("학교 이메일을 입력해주세요")
+                        .font(.pretendard(._500, size: 24))
                     
-                    VStack(spacing: 12) {
-                        Text("학교 이메일을 입력해주세요")
-                            .font(.pretendard(._500, size: 24))
-                        
-                        Text("대학교 인증을 완료해야\n내 팀을 만들 수 있어요!")
-                            .font(.pretendard(._400, size: 16))
-                    }
-                    
-                    if let univInfo = viewStore.universityInfo {
-                        HStack(spacing: 12) {
-                            WeaveTextField(
-                                text: viewStore.$emailPrefix,
-                                placeholder: "welcome"
-                            )
-                            
-                            Text("@" + univInfo.domainAddress)
-                                .font(.pretendard(._500, size: 18))
-                                .foregroundStyle(DesignSystem.Colors.lightGray)
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 24)
-                    }
-                    
-                    Spacer()
-                    
-                    WeaveButton(
-                        title: "인증메일 보내기",
-                        size: .large,
-                        isEnabled: !viewStore.emailPrefix.isEmpty && viewStore.universityInfo != nil
-                    ) {
-                        viewStore.send(.requestSendVerifyEmail)
-                    }
-                    .navigationDestination(isPresented: viewStore.$pushToNextView, destination: {
-                        UnivEmailVerifyView(
-                            store: .init(
-                                initialState: UnivEmailVerifyFeature.State(
-                                    userEmail: viewStore.emailPrefix + "@" + (viewStore.universityInfo?.domainAddress ?? "")
-                                ),
-                                reducer: {
-                                    UnivEmailVerifyFeature()
-                                }
-                            )
-                        )
-                    })
-                    .frame(height: 56)
-                    .padding(.horizontal, 16)
-                    .weaveAlert(
-                        isPresented: viewStore.$isShowEmailSendAlert,
-                        title: "✅\n인증번호 발송 완료!",
-                        message: "메일로 인증번호가 발송되었어요.\n메일을 확인해 인증번호를 입력해 주세요.",
-                        primaryButtonTitle: "네, 좋아요",
-                        primaryAction: {
-                            viewStore.send(.pushNextView)
-                        }
-                    )
-                    .weaveAlert(
-                        isPresented: viewStore.$isShowEmailSendErrorAlert,
-                        title: "🚨\n잘못된 이메일",
-                        message: "이메일 전송에 실패했어요.\n이메일 주소를 다시 확인해주세요",
-                        primaryButtonTitle: "다시 시도할께요"
-                    )
+                    Text("대학교 인증을 완료해야\n내 팀을 만들 수 있어요!")
+                        .font(.pretendard(._400, size: 16))
                 }
-                .onAppear {
+                
+                if let univInfo = viewStore.universityInfo {
+                    HStack(spacing: 12) {
+                        WeaveTextField(
+                            text: viewStore.$emailPrefix,
+                            placeholder: "welcome"
+                        )
+                        
+                        Text("@" + univInfo.domainAddress)
+                            .font(.pretendard(._500, size: 18))
+                            .foregroundStyle(DesignSystem.Colors.lightGray)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 24)
+                }
+                
+                Spacer()
+                
+                WeaveButton(
+                    title: "인증메일 보내기",
+                    size: .large,
+                    isEnabled: !viewStore.emailPrefix.isEmpty && viewStore.universityInfo != nil
+                ) {
+                    viewStore.send(.requestSendVerifyEmail)
+                }
+                .frame(height: 56)
+                .padding(.horizontal, 16)
+                .weaveAlert(
+                    isPresented: viewStore.$isShowEmailSendAlert,
+                    title: "✅\n인증번호 발송 완료!",
+                    message: "메일로 인증번호가 발송되었어요.\n메일을 확인해 인증번호를 입력해 주세요.",
+                    primaryButtonTitle: "네, 좋아요",
+                    primaryAction: {
+                        viewStore.send(.pushNextView)
+                    }
+                )
+                .weaveAlert(
+                    isPresented: viewStore.$isShowEmailSendErrorAlert,
+                    title: "🚨\n잘못된 이메일",
+                    message: "이메일 전송에 실패했어요.\n이메일 주소를 다시 확인해주세요",
+                    primaryButtonTitle: "다시 시도할께요"
+                )
+            }
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                     viewStore.send(.requestUniversityInfo)
                 }
-                .toolbarTitleDisplayMode(.inline)
-                .navigationTitle("대학교 인증")
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Image(systemName: "chevron.left")
-                    }
+            }
+            .navigationBarBackButtonHidden()
+            .toolbarTitleDisplayMode(.inline)
+            .navigationTitle("대학교 인증")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Image(systemName: "chevron.left")
                 }
+            }
+            .navigationDestination(
+                store: self.store.scope(state: \.$destination, action: { .destination($0) }),
+                state: /UnivEmailInputFeature.Destination.State.emailVerify,
+                action: UnivEmailInputFeature.Destination.Action.emailVerify
+            ) { store in
+                UnivEmailVerifyView(store: store)
             }
         }
     }

--- a/weave-iOS/Projects/App/Sources/MyPage/UnivVerification/View/UnivEmailVerifyView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/UnivVerification/View/UnivEmailVerifyView.swift
@@ -12,84 +12,82 @@ import ComposableArchitecture
 struct UnivEmailVerifyView: View {
     
     let store: StoreOf<UnivEmailVerifyFeature>
-
+    
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-            NavigationStack {
-                VStack {
-                    VStack(spacing: 12) {
-                        Text(
+            VStack {
+                VStack(spacing: 12) {
+                    Text(
                         """
                         받은 인증번호 6자리를
                         입력해 주세요
                         """
-                        )
-                        .multilineTextAlignment(.center)
-                        .font(.pretendard(._500, size: 24))
-                        
-                        HStack(spacing: 2) {
-                            Image(systemName: "stopwatch")
-                            Text(processSecondToString(time: viewStore.remainTime))
-                        }
-                        .font(.pretendard(._500, size: 16))
-                        .foregroundStyle(DesignSystem.Colors.lightGray)
-                    }
-                    .padding(.top, 30)
-                    .padding(.bottom, 20)
-                    
-                    VerifyCodeInputView(
-                        verifyCode: viewStore.$verifyCode,
-                        errorMessage: viewStore.$errorMessage
                     )
+                    .multilineTextAlignment(.center)
+                    .font(.pretendard(._500, size: 24))
                     
-                    if let errorMessage = viewStore.errorMessage {
-                        Spacer()
-                            .frame(height: 16)
-                        
-                        Text(errorMessage)
-                            .font(.pretendard(._400, size: 12))
-                            .foregroundStyle(DesignSystem.Colors.notificationRed)
+                    HStack(spacing: 2) {
+                        Image(systemName: "stopwatch")
+                        Text(processSecondToString(time: viewStore.remainTime))
                     }
-                    
+                    .font(.pretendard(._500, size: 16))
+                    .foregroundStyle(DesignSystem.Colors.lightGray)
+                }
+                .padding(.top, 30)
+                .padding(.bottom, 20)
+                
+                VerifyCodeInputView(
+                    verifyCode: viewStore.$verifyCode,
+                    errorMessage: viewStore.$errorMessage
+                )
+                
+                if let errorMessage = viewStore.errorMessage {
                     Spacer()
+                        .frame(height: 16)
                     
-                    HStack {
-                        Button(action: {
-                            viewStore.send(.didTappedRetrySendButton)
-                        }, label: {
-                            Image(systemName: "goforward").rotationEffect(.degrees(90))
-                            Text("인증번호 다시 받기")
-                                .font(.pretendard(._400, size: 14))
-                        })
-                    }
-                    .foregroundStyle(DesignSystem.Colors.defaultBlue)
-                    .frame(height: 40)
-                    .weaveAlert(
-                        isPresented: viewStore.$showRetrySendEmailAlert,
-                        title: "✅\n인증번호 재발송 완료",
-                        message: "메일로 인증번호가 재발송되었어요.\n메일을 확인해 인증번호를 입력해주세요.",
-                        primaryButtonTitle: "네, 좋아요"
-                    )
-                    
-                    WeaveButton(
-                        title: "학교 인증하기",
-                        size: .large,
-                        isEnabled: viewStore.verifyCode.count == 6 && viewStore.remainTime > 0
-                    ) {
-                        viewStore.send(.didTappedVerifyButton)
-                    }
-                    .padding(.horizontal, 16)
+                    Text(errorMessage)
+                        .font(.pretendard(._400, size: 12))
+                        .foregroundStyle(DesignSystem.Colors.notificationRed)
                 }
-                .onAppear {
-                    viewStore.send(.startTimer)
+                
+                Spacer()
+                
+                HStack {
+                    Button(action: {
+                        viewStore.send(.didTappedRetrySendButton)
+                    }, label: {
+                        Image(systemName: "goforward").rotationEffect(.degrees(90))
+                        Text("인증번호 다시 받기")
+                            .font(.pretendard(._400, size: 14))
+                    })
                 }
-                .navigationTitle("대학교 인증")
-                .navigationBarBackButtonHidden()
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Image(systemName: "chevron.left")
-                    }
+                .foregroundStyle(DesignSystem.Colors.defaultBlue)
+                .frame(height: 40)
+                .weaveAlert(
+                    isPresented: viewStore.$showRetrySendEmailAlert,
+                    title: "✅\n인증번호 재발송 완료",
+                    message: "메일로 인증번호가 재발송되었어요.\n메일을 확인해 인증번호를 입력해주세요.",
+                    primaryButtonTitle: "네, 좋아요"
+                )
+                
+                WeaveButton(
+                    title: "학교 인증하기",
+                    size: .large,
+                    isEnabled: viewStore.verifyCode.count == 6 && viewStore.remainTime > 0
+                ) {
+                    viewStore.send(.didTappedVerifyButton)
+                }
+                .padding(.horizontal, 16)
+            }
+            .onAppear {
+                viewStore.send(.startTimer)
+            }
+            .navigationTitle("대학교 인증")
+            .navigationBarBackButtonHidden()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Image(systemName: "chevron.left")
                 }
             }
         }


### PR DESCRIPTION
## 구현사항
- 기존에 만들어뒀던 학교 메일 인증 뷰의 destination 구조를 MyPage 뷰와 연결시킴
- 메일 인증 이후에는 RootView인 탭뷰로 이동하여 인증 완료 Alert이 나오도록 구현
- 학교 메일 인증 완료 뷰 도 새로 구현

## 스크린샷(선택)
|인증 완료 뷰|
|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/5fa94f27-8114-420f-a0a1-c9d4b33efc8e" width="400">|