### PR TITLE
[WEAV-304] 카카오 ID 설정 

### DIFF
--- a/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/Feature/SetKakaoIdFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/Feature/SetKakaoIdFeature.swift
@@ -44,7 +44,7 @@ struct SetKakaoIdFeature: Reducer {
             case .requestSetId:
                 return .run { [id = state.kakaoIdText] send in
                     try await requestSetKakaoId(id: id)
-                    await send.callAsFunction(.dismiss)
+                    await send.callAsFunction(.didCompleteSetId)
                 } catch: { error, send in
                     print(error)
                 }

--- a/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/Feature/SetKakaoIdFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/Feature/SetKakaoIdFeature.swift
@@ -1,0 +1,73 @@
+//
+//  SetKakaoIdFeature.swift
+//  weave-ios
+//
+//  Created by Jisu Kim on 3/22/24.
+//
+
+import Foundation
+import ComposableArchitecture
+import Services
+
+struct SetKakaoIdFeature: Reducer {
+    @Dependency(\.dismiss) var dismiss
+    
+    struct State: Equatable {
+        @BindingState var kakaoIdText: String
+        
+        @BindingState var isShowConfirmAlert = false
+        @BindingState var isShowCompleteAlert = false
+        
+        init() {
+            self.kakaoIdText = String()
+        }
+    }
+    
+    enum Action: BindableAction {
+        case didTappedSaveButton
+        case requestSetId
+        case didCompleteSetId
+        
+        case dismiss
+        case binding(BindingAction<State>)
+    }
+    
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .didTappedSaveButton:
+                state.isShowConfirmAlert.toggle()
+                return .none
+                
+            case .requestSetId:
+                return .run { [id = state.kakaoIdText] send in
+                    try await requestSetKakaoId(id: id)
+                    await send.callAsFunction(.dismiss)
+                } catch: { error, send in
+                    print(error)
+                }
+                
+            case .didCompleteSetId:
+                state.isShowCompleteAlert.toggle()
+                return .none
+                
+            case .dismiss:
+                return .run { send in
+                    await dismiss()
+                }
+                
+            default:
+                return .none
+            }
+        }
+    }
+    
+    func requestSetKakaoId(id: String) async throws {
+        let endPoint = APIEndpoints.setMyKakaoId(kakaoId: id)
+        let provider = APIProvider()
+        try await provider.requestWithNoResponse(with: endPoint)
+    }
+}
+

--- a/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/Model/Network/SetKakaoIdRequestDTO.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/Model/Network/SetKakaoIdRequestDTO.swift
@@ -1,0 +1,27 @@
+//
+//  SetKakaoIdRequestDTO.swift
+//  weave-ios
+//
+//  Created by Jisu Kim on 3/22/24.
+//
+
+import Foundation
+import Services
+
+fileprivate struct SetKakaoIdRequestDTO: Encodable {
+    let kakaoId: String
+}
+
+extension APIEndpoints {
+    static func setMyKakaoId(kakaoId: String) -> EndPoint<EmptyResponse> {
+        let request = SetKakaoIdRequestDTO(kakaoId: kakaoId)
+        return EndPoint(
+            path: "api/users/my/kakao-id",
+            method: .patch,
+            bodyParameters: request,
+            headers: [
+                "Authorization": "Bearer \(UDManager.accessToken)"
+            ]
+        )
+    }
+}

--- a/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/View/SetKakaoIdView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/View/SetKakaoIdView.swift
@@ -19,7 +19,7 @@ struct SetKakaoIdView: View {
                 Text("카카오톡 ID를 입력해 주세요")
                     .frame(height: 80)
                     .font(.pretendard(._500, size: 24))
-                    .padding(.top, 40)
+                    .padding(.top, 25)
                 
                 Text("미팅 날짜와 시간을 잡기 위해\n필요해요!")
                     .font(.pretendard(._500, size: 16))
@@ -49,13 +49,13 @@ struct SetKakaoIdView: View {
                     viewStore.send(.didTappedSaveButton)
                 }
                 .weaveAlert(
-                    isPresented: viewStore.$isShowCompleteAlert,
+                    isPresented: viewStore.$isShowConfirmAlert,
                     title: "✅\n확인해주세요",
-                    message: "입력하신 Id는\n\(viewStore.kakaoIdText)입니다.\n정확히 입력하셨나요??",
+                    message: "입력하신 카카오톡 ID는\n\(viewStore.kakaoIdText)입니다.\n정확히 입력하셨나요??",
                     primaryButtonTitle: "네 맞아요",
                     secondaryButtonTitle: "다시 입력",
                     primaryAction: {
-                        viewStore.send(.didTappedSaveButton)
+                        viewStore.send(.requestSetId)
                     }
                 )
                 .weaveAlert(
@@ -68,8 +68,12 @@ struct SetKakaoIdView: View {
                     }
                 )
             }
+            .onAppear {
+                UIApplication.shared.hideKeyboard()
+            }
             .padding(.horizontal, 16)
             .navigationTitle("연락 수단")
+            .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden()
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {

--- a/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/View/SetKakaoIdView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/EditProfile/KakaoId/View/SetKakaoIdView.swift
@@ -1,0 +1,95 @@
+//
+//  SetKakaoIdView.swift
+//  weave-ios
+//
+//  Created by Jisu Kim on 3/22/24.
+//
+
+import SwiftUI
+import DesignSystem
+import ComposableArchitecture
+
+struct SetKakaoIdView: View {
+    
+    let store: StoreOf<SetKakaoIdFeature>
+    
+    var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            VStack(spacing: 12) {
+                Text("카카오톡 ID를 입력해 주세요")
+                    .frame(height: 80)
+                    .font(.pretendard(._500, size: 24))
+                    .padding(.top, 40)
+                
+                Text("미팅 날짜와 시간을 잡기 위해\n필요해요!")
+                    .font(.pretendard(._500, size: 16))
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, 20)
+                
+                HStack {
+                    WeaveTextField(
+                        text: viewStore.$kakaoIdText,
+                        placeholder: "카카오톡 ID",
+                        textAlignment: .leading, 
+                        showClearButton: true
+                    )
+                }
+                
+                Text("한 번 저장하면 변경하기 어려우니 신중히 작성해 주세요!")
+                    .font(.pretendard(._400, size: 14))
+                    .foregroundStyle(DesignSystem.Colors.gray600)
+                
+                Spacer()
+                
+                WeaveButton(
+                    title: "저장하기",
+                    size: .large,
+                    isEnabled: viewStore.kakaoIdText != ""
+                ) {
+                    viewStore.send(.didTappedSaveButton)
+                }
+                .weaveAlert(
+                    isPresented: viewStore.$isShowCompleteAlert,
+                    title: "✅\n확인해주세요",
+                    message: "입력하신 Id는\n\(viewStore.kakaoIdText)입니다.\n정확히 입력하셨나요??",
+                    primaryButtonTitle: "네 맞아요",
+                    secondaryButtonTitle: "다시 입력",
+                    primaryAction: {
+                        viewStore.send(.didTappedSaveButton)
+                    }
+                )
+                .weaveAlert(
+                    isPresented: viewStore.$isShowCompleteAlert,
+                    title: "🎉\n카카오 Id 설정이 완료되었어요.",
+                    message: "이제 얼른 미팅을 잡아보세요!",
+                    primaryButtonTitle: "확인",
+                    primaryAction: {
+                        viewStore.send(.dismiss)
+                    }
+                )
+            }
+            .padding(.horizontal, 16)
+            .navigationTitle("연락 수단")
+            .navigationBarBackButtonHidden()
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: {
+                        viewStore.send(.dismiss)
+                    }, label: {
+                        Image(systemName: "chevron.left")
+                    })
+                    .foregroundStyle(.white)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SetKakaoIdView(
+        store: Store(
+            initialState: SetKakaoIdFeature.State()) {
+                SetKakaoIdFeature()
+            }
+    )
+}

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
@@ -111,6 +111,8 @@ struct MyPageFeature: Reducer {
                         return .none
                     }
                     state.destination = .univVerify(.init(universityName: state.myUserInfo?.universityName ?? ""))
+                    return .none
+                }
                 
                 return .none
                 

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
@@ -74,6 +74,12 @@ struct MyPageFeature: Reducer {
                 
             case .didTappedSubViews(let type):
                 switch type {
+                case .kakaoTalkId:
+                    if state.myUserInfo?.kakaoId == "" || state.myUserInfo?.kakaoId == nil {
+                        state.destination = .setKakaoId(.init())
+                    }
+                    return .none
+                    
                 case .mbti:
                     state.destination = .editMbti(
                         .init(
@@ -192,6 +198,7 @@ extension MyPageFeature {
     struct Destination: Reducer {
         enum State: Equatable {
             case presentSetting(SettingFeautre.State)
+            case setKakaoId(SetKakaoIdFeature.State)
             case editMbti(MyMbtiEditFeature.State)
             case editAnimal(MyAnimalSelectionFeature.State)
             case editHeight(MyHeightEditFeature.State)
@@ -199,6 +206,7 @@ extension MyPageFeature {
         }
         enum Action {
             case presentSetting(SettingFeautre.Action)
+            case setKakaoId(SetKakaoIdFeature.Action)
             case editMbti(MyMbtiEditFeature.Action)
             case editAnimal(MyAnimalSelectionFeature.Action)
             case editHeight(MyHeightEditFeature.Action)
@@ -207,6 +215,9 @@ extension MyPageFeature {
         var body: some ReducerOf<Self> {
             Scope(state: /State.presentSetting, action: /Action.presentSetting) {
                 SettingFeautre()
+            }
+            Scope(state: /State.setKakaoId, action: /Action.setKakaoId) {
+                SetKakaoIdFeature()
             }
             Scope(state: /State.editMbti, action: /Action.editMbti) {
                 MyMbtiEditFeature()

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
@@ -111,9 +111,6 @@ struct MyPageFeature: Reducer {
                         return .none
                     }
                     state.destination = .univVerify(.init(universityName: state.myUserInfo?.universityName ?? ""))
-                    
-                default: break
-                }
                 
                 return .none
                 

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Model/Network/Domain/MyPageCategoryTypes.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Model/Network/Domain/MyPageCategoryTypes.swift
@@ -82,7 +82,7 @@ enum MyPageCategoryTypes: CaseIterable {
         func isSubMenuFilled(_ userModel: MyUserInfoModel) -> Bool {
             switch self {
             case .kakaoTalkId:
-                return false
+                return userModel.kakaoId != ""
             case .mbti:
                 return userModel.mbti != ""
             case .similarAnimal:
@@ -100,7 +100,7 @@ enum MyPageCategoryTypes: CaseIterable {
             }
             
             switch self {
-            case .kakaoTalkId: return ""
+            case .kakaoTalkId: return userModel.kakaoId ?? ""
             case .mbti: return userModel.mbti
             case .similarAnimal: return userModel.animalType ?? ""
             case .physicalHeight: return String(userModel.height ?? 0)

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Model/Network/Domain/MyUserInfoModel.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Model/Network/Domain/MyUserInfoModel.swift
@@ -17,6 +17,7 @@ struct MyUserInfoModel: Equatable {
     let mbti: String
     let animalType: String?
     let height: Int?
+    let kakaoId: String?
     let isUniversityEmailVerified: Bool
     let sil: Int
     

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Model/Network/ResponseDTO/MyUserInfoResponseDTO.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Model/Network/ResponseDTO/MyUserInfoResponseDTO.swift
@@ -18,6 +18,7 @@ struct MyUserInfoResponseDTO: Decodable {
     let mbti: String
     let animalType: String?
     let height: Int?
+    let kakaoId: String?
     let isUniversityEmailVerified: Bool
     let sil: Int
     
@@ -32,6 +33,7 @@ struct MyUserInfoResponseDTO: Decodable {
             mbti: mbti,
             animalType: animalType,
             height: height,
+            kakaoId: kakaoId,
             isUniversityEmailVerified: isUniversityEmailVerified,
             sil: `sil`
         )

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/View/MyPageView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/View/MyPageView.swift
@@ -89,6 +89,14 @@ struct MyPageView: View {
                     SettingView(store: store)
                         .environmentObject(AppCoordinator.shared)
                 }
+                // 카카오 Id 설정
+                .navigationDestination(
+                    store: self.store.scope(state: \.$destination, action: { .destination($0) }),
+                    state: /MyPageFeature.Destination.State.setKakaoId,
+                    action: MyPageFeature.Destination.Action.setKakaoId
+                ) { store in
+                    SetKakaoIdView(store: store)
+                }
                 // 대학교 인증
                 .navigationDestination(
                     store: self.store.scope(state: \.$destination, action: { .destination($0) }),


### PR DESCRIPTION
## 구현사항
- 마이페이지에서 카카오 ID를 설정하는 기능
- 카카오 ID 설정 뷰, 로직


## 스크린샷(선택)
|카카오톡 ID 설정 1|카카오톡 ID 설정 2|
|:---:|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/9ea5e405-d91b-4a60-9756-c190bf0156a7" width="400">|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/2bacb96a-1501-44c3-bbb4-595b5f96d3ad" width="400">