### PR TITLE
[WEAV-286] App Scheme 통한 앱 메뉴 랜딩 구현

### DIFF
--- a/weave-iOS/Projects/App/Project.swift
+++ b/weave-iOS/Projects/App/Project.swift
@@ -23,7 +23,6 @@ let target = Target(
         .package(product: "KakaoSDKUser", type: .macro),
         .package(product: "KakaoSDKShare", type: .macro),
         .package(product: "KakaoSDKTemplate", type: .macro),
-        .external(name: "Kingfisher"),
     ]
 )
 

--- a/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
+++ b/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
@@ -73,6 +73,20 @@ struct MeetingTeamListView: View {
                     }
                 }
                 .toolbar(.visible, for: .tabBar)
+                .onOpenURL(perform: { url in
+                    guard url.host(percentEncoded: true)?.contains("kakaolink") == true else { return }
+                    
+                    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+                          let queryItems = components.queryItems else { return }
+                    
+                    let type = queryItems.first { $0.name == "type" }?.value
+                    let code = queryItems.first { $0.name == "teamId" }?.value
+                    
+                    if type == "team",
+                        let teamId = code {
+                        viewStore.send(.didTappedTeamView(id: teamId))
+                    }
+                })
                 .navigationDestination(
                     store: self.store.scope(state: \.$destination, action: { .destination($0) }),
                     state: /MeetingTeamListFeature.Destination.State.teamDetail,

--- a/weave-iOS/Projects/App/Sources/KakaoShare/KakaoShareManager.swift
+++ b/weave-iOS/Projects/App/Sources/KakaoShare/KakaoShareManager.swift
@@ -20,8 +20,8 @@ class KakaoShareManager {
                         "title": "[WEAVE] 친구야 이 팀 어때?",
                         "image_url": "\(SecretKey.serverResourcePath)/share_image.png",
                         "link": {
-                            "mobile_web_url": "\(SecretKey.serverResourcePath)/share_image.png",
-                            "web_url": "\(SecretKey.serverResourcePath)/share_image.png"
+                            "ios_execution_params": "type=team&teamId=\(teamId)",
+                            "androidExecutionParams": "type=team&teamId=\(teamId)"
                         },
                     },
                     "buttons": [
@@ -29,7 +29,7 @@ class KakaoShareManager {
                             "title": "팀 상세보기",
                             "link": {
                                 "ios_execution_params": "type=team&teamId=\(teamId)",
-                                "web_url": "https://developers.kakao.com"
+                                "androidExecutionParams": "type=team&teamId=\(teamId)"
                             }
                         }
                     ]
@@ -46,16 +46,16 @@ class KakaoShareManager {
                         "title": "[WEAVE] 친구야 같이 미팅하자",
                         "image_url": "\(SecretKey.serverResourcePath)/share_image.png",
                         "link": {
-                            "mobile_web_url": "\(SecretKey.serverResourcePath)/share_image.png",
-                            "web_url": "\(SecretKey.serverResourcePath)/share_image.png"
+                                "androidExecutionParams": "type=invitation&code=\(code)",
+                                "ios_execution_params": "type=invitation&code=\(code)"
                         },
                     },
                     "buttons": [
                         {
-                            "title": "팀 상세보기",
+                            "title": "초대장 확인하기",
                             "link": {
                                 "ios_execution_params": "type=invitation&code=\(code)",
-                                "web_url": "https://developers.kakao.com"
+                                "androidExecutionParams": "type=invitation&code=\(code)"
                             }
                         }
                     ]

--- a/weave-iOS/Projects/App/Sources/Navigation/AppTabView.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/AppTabView.swift
@@ -94,7 +94,6 @@ struct AppTabView: View {
                 viewStore.send(.onAppear)
             }
             .onOpenURL { url in
-                print(url)
                 guard url.host(percentEncoded: true)?.contains("kakaolink") == true else { return }
                 
                 guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
@@ -105,7 +104,6 @@ struct AppTabView: View {
                 
                 if type == "invitation", 
                     let invitationCode = code {
-                    print("Invitation Code: \(invitationCode)")
                     viewStore.send(.didInvitationReceived(invitationCode: invitationCode))
                 }
             }

--- a/weave-iOS/Projects/App/Sources/Navigation/AppTabView.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/AppTabView.swift
@@ -93,6 +93,35 @@ struct AppTabView: View {
             .onLoad {
                 viewStore.send(.onAppear)
             }
+            .onOpenURL { url in
+                print(url)
+                guard url.host(percentEncoded: true)?.contains("kakaolink") == true else { return }
+                
+                guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+                      let queryItems = components.queryItems else { return }
+                
+                let type = queryItems.first { $0.name == "type" }?.value
+                let code = queryItems.first { $0.name == "code" }?.value
+                
+                if type == "invitation", 
+                    let invitationCode = code {
+                    print("Invitation Code: \(invitationCode)")
+                    viewStore.send(.didInvitationReceived(invitationCode: invitationCode))
+                }
+            }
+            .weaveAlert(
+                isPresented: viewStore.$isShowInvitationConfirmAlert,
+                title: "✉️\n팀 초대장 도착!",
+                message: "\(viewStore.invitedTeamInfo?.teamIntroduce ?? "") 팀의 초대를 수락할까요?",
+                primaryButtonTitle: "수락할께요",
+                secondaryButtonTitle: "나중에",
+                primaryAction: {
+                    viewStore.send(.didTappedAcceptInvitation)
+                },
+                secondaryAction: {
+                    viewStore.send(.didTappedCancelInvitation)
+                }
+            )
         }
     }
 }

--- a/weave-iOS/Projects/App/Sources/Navigation/AppTabViewFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/AppTabViewFeature.swift
@@ -13,6 +13,10 @@ struct AppTabViewFeature: Reducer {
     struct State: Equatable {
         @BindingState var selection: AppScreen = .home
         
+        @BindingState var isShowInvitationConfirmAlert = false
+        
+        var invitedTeamInfo: MeetingTeamInfoModel?
+        
         // Tap SubView States
         var matchedMeeting = MatchedMeetingListFeature.State()
         var requestList = RequestListFeature.State()
@@ -28,6 +32,13 @@ struct AppTabViewFeature: Reducer {
         
         case requestMyUserInfo
         case fetchMyUserInfo(userInfo: MyUserInfoResponseDTO)
+        
+        // App Scheme Action
+        case didInvitationReceived(invitationCode: String)
+        case processWithInvitedTeamInfo(team: MeetingTeamInfoModel)
+        case didTappedAcceptInvitation
+        case didTappedCancelInvitation
+        case didSuccessEnterTeam
         
         // Tap SubView Actions
         case matchedMeeting(MatchedMeetingListFeature.Action)
@@ -55,6 +66,42 @@ struct AppTabViewFeature: Reducer {
                 
             case .fetchMyUserInfo(let userInfo):
                 UserInfo.myInfo = userInfo.toDomain
+                return .none
+                
+            case .didInvitationReceived(let invitationCode):
+                return .run { send in
+                    let response = try await requestInvitedTeamInfo(invitationCode: invitationCode)
+                    var teamInfo = response.toDomain
+                    teamInfo.invitationCode = invitationCode
+                    await send.callAsFunction(.processWithInvitedTeamInfo(team: teamInfo))
+                } catch: { error, send in
+                    print(error)
+                    // 에러처리 필요
+                }
+                
+            case .processWithInvitedTeamInfo(let invitedTeam):
+                state.invitedTeamInfo = invitedTeam
+                state.isShowInvitationConfirmAlert.toggle()
+                return .none
+                
+            case .didTappedAcceptInvitation:
+                guard let invitationCode = state.invitedTeamInfo?.invitationCode else { return .none }
+                state.invitedTeamInfo = nil
+                return .run { send in
+                    try await requestAcceptInvitation(invitationCode: invitationCode)
+                    await send.callAsFunction(.didSuccessEnterTeam)
+                } catch: { error, send in
+                    // ToDo -
+                    // 팀원 초과 에러
+                    // 만료된 초대장 에러 처리
+                }
+                
+            case .didSuccessEnterTeam:
+                state.selection = .myTeam
+                return .none
+                
+            case .didTappedCancelInvitation:
+                state.invitedTeamInfo = nil
                 return .none
             
             case .binding:
@@ -87,5 +134,18 @@ struct AppTabViewFeature: Reducer {
         let provider = APIProvider(session: URLSession.shared)
         let response = try await provider.request(with: endPoint)
         return response
+    }
+    
+    func requestInvitedTeamInfo(invitationCode: String) async throws -> MeetingTeamInfoResponseDTO {
+        let endPoint = APIEndpoints.getMeetingTeamInfo(invitationCode: invitationCode)
+        let provider = APIProvider()
+        let response = try await provider.request(with: endPoint)
+        return response
+    }
+    
+    func requestAcceptInvitation(invitationCode: String) async throws {
+        let endPoint = APIEndpoints.acceptInvitation(invitationCode)
+        let provider = APIProvider()
+        try await provider.requestWithNoResponse(with: endPoint)
     }
 }

--- a/weave-iOS/Projects/App/Sources/Navigation/Model/Domain/MeetingTeamInfoModel.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/Model/Domain/MeetingTeamInfoModel.swift
@@ -1,0 +1,15 @@
+//
+//  MeetingTeamInfoModel.swift
+//  weave-ios
+//
+//  Created by Jisu Kim on 3/26/24.
+//
+
+import Foundation
+
+struct MeetingTeamInfoModel: Equatable {
+    let teamId: String
+    let teamIntroduce: String
+    let status: String
+    var invitationCode: String?
+}

--- a/weave-iOS/Projects/App/Sources/Navigation/Model/Network/MeetingTeamInfoResponseDTO.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/Model/Network/MeetingTeamInfoResponseDTO.swift
@@ -1,0 +1,45 @@
+//
+//  MeetingTeamInfoResponseDTO.swift
+//  weave-ios
+//
+//  Created by Jisu Kim on 3/26/24.
+//
+
+import Services
+import Foundation
+
+struct MeetingTeamInfoResponseDTO: Decodable {
+    let teamId: String
+    let teamIntroduce: String
+    let status: String
+    
+    var toDomain: MeetingTeamInfoModel {
+        return MeetingTeamInfoModel(
+            teamId: teamId,
+            teamIntroduce: teamIntroduce,
+            status: status
+        )
+    }
+}
+
+extension APIEndpoints {
+    static func getMeetingTeamInfo(invitationCode: String) -> EndPoint<MeetingTeamInfoResponseDTO> {
+        return EndPoint(
+            path: "api/meeting-teams/invitation/\(invitationCode)",
+            method: .get,
+            headers: [
+                "Authorization": "Bearer \(UDManager.accessToken)"
+            ]
+        )
+    }
+    
+    static func acceptInvitation(_ invitationCode: String) -> EndPoint<EmptyResponse> {
+        return EndPoint(
+            path: "api/meeting-teams/invitation/\(invitationCode)",
+            method: .post,
+            headers: [
+                "Authorization": "Bearer \(UDManager.accessToken)"
+            ]
+        )
+    }
+}

--- a/weave-iOS/Projects/DesignSystem/Project.swift
+++ b/weave-iOS/Projects/DesignSystem/Project.swift
@@ -13,6 +13,7 @@ let target = Target(
     dependencies: [
         .project(target: "CoreKit",
                  path: .relativeToRoot("Projects/Core")),
+        .external(name: "Kingfisher")
     ]
 )
 


### PR DESCRIPTION
## 구현사항
- 카카오톡 공유하기 메시지 수신을 통한 팀 입장 기능
- 친구에게 공유받은 미팅 팀 정보 확인하기

## 특이사항
- AOS, iOS간 상호 테스트 완료

## 스크린샷(선택)
|팀 초대 수신|팀 공유 수신|
|:---:|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/de409503-5377-44d4-88fd-2037610c8f1f" width="400">|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/6a8a6fd1-6432-4df5-9492-169f7bd95da3" width="400">
