### PR TITLE
[Fix] 리스트 뷰 에러 대응

### DIFF
--- a/weave-iOS/Projects/App/Sources/Chat/Feature/MatchedMeetingListFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Chat/Feature/MatchedMeetingListFeature.swift
@@ -26,6 +26,7 @@ struct MatchedMeetingListFeature: Reducer {
         case onAppear
         case didTappedTeamView(team: MatchedMeetingTeamInfo)
         
+        case networkRequestError
         // destination
         case destination(PresentationAction<Destination.Action>)
         
@@ -59,8 +60,12 @@ struct MatchedMeetingListFeature: Reducer {
                     let response = try await requestMatchedTeamList(nextId: nil)
                     await send.callAsFunction(.fetchMeetingTeamList(response: response))
                 } catch: { error, send in
+                    await send.callAsFunction(.networkRequestError)
                     print(error)
                 }
+            case .networkRequestError:
+                state.isNetworkRequested = true
+                return .none
             case .fetchMeetingTeamList(let response):
                 state.isNetworkRequested = true
                 state.teamList.append(contentsOf: response.toDomain.items)

--- a/weave-iOS/Projects/App/Sources/Request/Feature/RequestListFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Request/Feature/RequestListFeature.swift
@@ -28,6 +28,7 @@ struct RequestListFeature: Reducer {
         
         case requestList(type: RequestListType)
         case requestNextPage(type: RequestListType)
+        case processRequestError(type: RequestListType)
         
         case fetchData(dto: RequestMeetingListResponseDTO, type: RequestListType)
         case destination(PresentationAction<Destination.Action>)
@@ -70,6 +71,15 @@ struct RequestListFeature: Reducer {
                 }
                 return .none
                 
+            case .processRequestError(let type):
+                switch type {
+                case .receiving:
+                    state.isReceiveDataRequested = true
+                case .requesting:
+                    state.isSentDataRequested = true
+                }
+                return .none
+                
             case .destination(.dismiss):
                 state.destination = nil
                 return .none
@@ -97,7 +107,7 @@ struct RequestListFeature: Reducer {
                     let response = try await requestMeetingList(type: type)
                     await send.callAsFunction(.fetchData(dto: response, type: type))
                 } catch: { error, send in
-                    print(error)
+                    await send.callAsFunction(.processRequestError(type: type))
                 }
                 
             case .requestNextPage(let type):


### PR DESCRIPTION
## 구현사항
- 내 팀이 존재하지 않은 상태에서는 서버에서 400에러를 보냄
- 빈 배열만 처리하고 있고, 에러는 처리하지 않았던 기존 로직을 수정
- 리스트 조회에서 에러를 처리하는 action을 생성, 에러인 경우에도 기본 메시지가 보이도록 수정함
- 추후 다른 에러 처리도 동일 액션 이용하면 될 것으로 보임
