### PR TITLE
[Infra] App Target 및 Scheme prod와 dev로 나눔

### DIFF
--- a/weave-iOS/Projects/App/Project.swift
+++ b/weave-iOS/Projects/App/Project.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
-let target = Target(
-    name: "weave-ios",
+let prodTarget = Target(
+    name: "weave-ios-prod",
     platform: .iOS,
     product: .app,
     bundleId: "com.studentcenter.weaveios",
@@ -23,8 +23,49 @@ let target = Target(
         .package(product: "KakaoSDKUser", type: .macro),
         .package(product: "KakaoSDKShare", type: .macro),
         .package(product: "KakaoSDKTemplate", type: .macro),
-    ]
+    ],
+    settings: .settings(
+        base: setEnviroment(to: .prod)
+    )
 )
+
+let devTarget = Target(
+    name: "weave-ios-dev",
+    platform: .iOS,
+    product: .app,
+    bundleId: "com.studentcenter.weaveios",
+    deploymentTarget: .iOS(targetVersion: "17.0",
+                           devices: .iphone,
+                           supportsMacDesignedForIOS: false),
+    infoPlist: .file(path: "Support/weave-ios-Info.plist"),
+    sources: ["Sources/**"],
+    resources: ["Resources/**"],
+    entitlements: .file(path: .relativeToCurrentFile("weave-ios.entitlements")),
+    dependencies: [
+        .project(target: "Services",
+                 path: .relativeToRoot("Projects/Core")),
+        .project(target: "DesignSystem",
+                 path: .relativeToRoot("Projects/DesignSystem")),
+        .package(product: "ComposableArchitecture", type: .macro),
+        .package(product: "KakaoSDKCommon", type: .macro),
+        .package(product: "KakaoSDKAuth", type: .macro),
+        .package(product: "KakaoSDKUser", type: .macro),
+        .package(product: "KakaoSDKShare", type: .macro),
+        .package(product: "KakaoSDKTemplate", type: .macro),
+    ],
+    settings: .settings(
+        base: setEnviroment(to: .dev)
+    )
+)
+
+public enum AppEnviroment: String {
+    case dev
+    case prod
+}
+
+public func setEnviroment(to env: AppEnviroment) -> SettingsDictionary {
+    return .init(dictionaryLiteral: ("AppEnviroment", .string(env.rawValue)))
+}
 
 let project = Project(
     name: "Weave-ios",
@@ -37,7 +78,7 @@ let project = Project(
         .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .branch("master"))
     ],
     settings: nil,
-    targets: [target],
+    targets: [prodTarget, devTarget],
     schemes: [],
     fileHeaderTemplate: nil,
     additionalFiles: [],

--- a/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Profile/Feature/MyPageFeature.swift
@@ -142,6 +142,10 @@ struct MyPageFeature: Reducer {
                 appCoordinator.changeRoot(to: .loginView)
                 return .none
                 
+            case .destination(.presented(.presentSetting(.didTappedDismiss))):
+                state.destination = nil
+                return .none
+                
             case .showPhotoPicker:
                 state.isShowPhotoPicker.toggle()
                 return .none

--- a/weave-iOS/Projects/App/Sources/MyPage/Setting/Feature/SettingFeautre.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Setting/Feature/SettingFeautre.swift
@@ -21,6 +21,7 @@ struct SettingFeautre: Reducer {
     
     enum Action: BindableAction {
         case inform
+        case didTappedDismiss
         case didTappedSubViews(view: SettingCategoryTypes.SettingSubViewTypes)
         case showLogoutAlert
         case showUnregisterAlert
@@ -72,6 +73,9 @@ struct SettingFeautre: Reducer {
                 }
                 
             case .resignSuccessed:
+                return .none
+                
+            case .didTappedDismiss:
                 return .none
                 
             case .binding(_):

--- a/weave-iOS/Projects/App/Sources/MyPage/Setting/View/SettingView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Setting/View/SettingView.swift
@@ -35,13 +35,19 @@ struct SettingView: View {
                     Spacer()
                         .frame(height: 12)
                 }
-                Spacer(minLength: 200)
-                HStack {
-                    // TODO: 레이아웃 조정
-                    Text("Version \(appVersion())")
-                    Text("최신버젼")
-                }
+                
                 Spacer()
+                
+                HStack(spacing: 10) {
+                    Text("Ver \(appVersion())")
+                        .font(.pretendard(._500, size: 14))
+                        .foregroundStyle(DesignSystem.Colors.gray400)
+                    Text("최신 버젼")
+                        .font(.pretendard(._600, size: 12))
+                        .foregroundStyle(DesignSystem.Colors.gray600)
+                }
+                .frame(height: 40)
+                .padding(.bottom, 60)
             }
             .padding(.horizontal, 16)
             .navigationTitle("설정")

--- a/weave-iOS/Projects/App/Sources/MyPage/Setting/View/SettingView.swift
+++ b/weave-iOS/Projects/App/Sources/MyPage/Setting/View/SettingView.swift
@@ -67,17 +67,20 @@ struct SettingView: View {
                     viewStore.send(.showUnregisterAlert)
                 }
             )
-            .weaveAlert(
-                isPresented: viewStore.$isShowPasteSuccessAlert,
-                title: "복사",
-                message: "조금만 있으면 새로운 기능들이 추가돼요!\n 한번 더 생각해보시는 건 어떠세요?",
-                primaryButtonTitle: "탈퇴할래요",
-                secondaryButtonTitle: "아니요",
-                primaryAction: {
-
-                }
+            .weaveToast(
+                isShowing: viewStore.$isShowPasteSuccessAlert, 
+                message: "✅ ID가 복사되었어요."
             )
-            // TODO: Weave Toast 추가
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        viewStore.send(.didTappedDismiss)
+                    } label: {
+                        Image(systemName: "chevron.left")
+                    }
+                    .foregroundStyle(.white)
+                }
+            }
         }
     }
     
@@ -120,7 +123,8 @@ struct SettingSubSectionView: View {
                 Spacer()
                 
                 if viewType == .myID {
-                    Text("kakaoID")
+                    Text(getClippedID())
+                        .font(.pretendard(._500, size: 14))
                         .foregroundStyle(DesignSystem.Colors.textGray)
                     DesignSystem.Icons.copyID
                         .fontWeight(.semibold)
@@ -134,6 +138,16 @@ struct SettingSubSectionView: View {
             
         }
         .frame(height: 54)
+    }
+    
+    func getClippedID() -> String {
+        let uuid = UserInfo.myInfo?.id ?? ""
+        if let range = uuid.range(of: "-") {
+            let shortUUID = uuid[..<range.lowerBound] + "..."
+            return String(shortUUID)
+        } else {
+            return String(uuid.prefix(8)) + "..."
+        }
     }
 }
 

--- a/weave-iOS/Projects/App/Support/weave-ios-Info.plist
+++ b/weave-iOS/Projects/App/Support/weave-ios-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/weave-iOS/Projects/App/Support/weave-ios-Info.plist
+++ b/weave-iOS/Projects/App/Support/weave-ios-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>App Enviroment</key>
+	<string>${AppEnviroment}</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/weave-iOS/Projects/DesignSystem/Sources/Toast/WeaveToast.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/Toast/WeaveToast.swift
@@ -15,7 +15,6 @@ public struct WeaveToast: View {
     var message: String
     let messageColor: Color
     let duration: TimeInterval
-    let transition: AnyTransition
     let animation: Animation
     
     init(
@@ -23,16 +22,15 @@ public struct WeaveToast: View {
         message: String,
         messageColor: Color = DesignSystem.Colors.white,
         duration: TimeInterval = WeaveToast.short,
-        transition: AnyTransition = .opacity,
-        animation: Animation = .linear(duration: 0.3)
+        animation: Animation = .easeOut(duration: 0.2)
     ) {
         self._isShowing = isShowing
         self.message = message
         self.messageColor = messageColor
         self.duration = duration
-        self.transition = transition
         self.animation = animation
     }
+    
     
     public var body: some View {
         VStack {
@@ -42,31 +40,32 @@ public struct WeaveToast: View {
                     Text(message)
                         .multilineTextAlignment(.leading)
                         .foregroundColor(messageColor)
-                        .font(.pretendard(._500, size: 22))
+                        .font(.pretendard(._500, size: 14))
                         .padding(.all, 16)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(DesignSystem.Colors.darkGray)
+                        .clipShape(RoundedRectangle(cornerRadius: 14.0))
                 }
-                .background(DesignSystem.Colors.darkGray)
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: 14.0
-                    )
-                )
+                .transition(AnyTransition.opacity.combined(with: .move(edge: .bottom)))
+                .animation(animation, value: isShowing)
                 .onTapGesture {
-                    isShowing = false
+                    withAnimation(animation) {
+                        isShowing = false
+                    }
                 }
                 .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        isShowing = false
+                    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                        withAnimation(animation) {
+                            isShowing = false
+                        }
                     }
                 }
             }
         }
         .padding(.horizontal, 16)
         .padding(.bottom, 16)
-        .frame(maxWidth: .infinity, alignment: .center)
+        .frame(maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .bottom)
         .animation(animation, value: isShowing)
-        .transition(transition)
     }
 }
 


### PR DESCRIPTION
## 구현사항
- 출시에 대비해 추후 App의 유지보수를 위해 prod와 dev 타겟으로 분리
- Scheme 도 각 타겟에 맞춰 분리 진행

## 특이사항
- 각 타겟의 buildSetting에 AppEnviroment 키를 이용해 dev와 prod 분기
- 앱의 런타임에서 환경 정보를 읽어와 각 서버 환경을 바라보도록 구현

## 고민(선택)
- Target의 bundleId를 분리하는 방법도 생각해봐도 좋을것같아요.