### PR TITLE
[WEAV-328] 웹 카카오 로그인 지원, 앱/로그인 Feature 구조 변경

### DIFF
--- a/weave-iOS/Projects/App/Sources/AppView/AppViewFeature.swift
+++ b/weave-iOS/Projects/App/Sources/AppView/AppViewFeature.swift
@@ -67,6 +67,21 @@ struct AppViewFeature: Reducer {
                 state.mainState?.isShowWelcomeAlert = true
                 return .none
                 
+            // 로그인 성공
+            case .loginAction(.didSuccessedLogin):
+                return .send(.changeRoot(.mainView), animation: .default)
+                
+            // 회원가입 필요
+            case .loginAction(.needRegistUser):
+                if let registerToken = state.loginState?.registerToken {
+                    return .send(.changeRoot(.signUpView(registToken: registerToken)), animation: .default)
+                }
+                return .none
+                
+            // 회원가입 취소 액션
+            case .signUpAction(.dismissSignUp):
+                return .send(.changeRoot(.loginView), animation: .default)
+                
             default:
                 break
             }

--- a/weave-iOS/Projects/App/Sources/Login/KakaoLoginButton.swift
+++ b/weave-iOS/Projects/App/Sources/Login/KakaoLoginButton.swift
@@ -50,6 +50,18 @@ struct KakaoLoginButton: View {
                         onComplte(idToken)
                     }
                 }
+            } 
+        } else {
+            UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                if let error = error {
+                    print("loginWithKakaoTalk error: \(error)")
+                } else {
+                    print("loginWithKakaoTalk() success.")
+                    if let idToken = oauthToken?.idToken {
+                        print("oauthToken: \(idToken)")
+                        onComplte(idToken)
+                    }
+                }
             }
         }
     }

--- a/weave-iOS/Projects/App/Sources/Login/LoginFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Login/LoginFeature.swift
@@ -15,10 +15,15 @@ struct LoginFeature: Reducer {
     
     struct State: Equatable {
         @BindingState var needShowErrorAlert = false
+        var registerToken: String?
     }
     
     enum Action: BindableAction {
         case didTappedLoginButton(idToken: String, type: SNSLoginType)
+        
+        case didSuccessedLogin
+        case fetchRegisterToken(registerToken: String)
+        case needRegistUser
         
         case binding(BindingAction<State>)
     }
@@ -28,8 +33,27 @@ struct LoginFeature: Reducer {
         Reduce { state, action in
             switch action {
             case .didTappedLoginButton(let idToken, let type):
-                requestSNSLogin(idToken: idToken, with: type)
+                return .run { send in
+                    try await requestSNSLogin(idToken: idToken, with: type)
+                    try await UserInfo.updateUserInfo()
+                    await send.callAsFunction(.didSuccessedLogin)
+                } catch: { error, send in
+                    switch error as? LoginNetworkError {
+                    case .needRegist(let registerTokenResponse):
+                        await send.callAsFunction(.fetchRegisterToken(registerToken: registerTokenResponse.registerToken))
+                    case .none:
+                        return
+                    }
+                }
+                
+            case .didSuccessedLogin:
+//                appCoordinator.changeRoot(to: .mainView)
                 return .none
+                
+            case .fetchRegisterToken(let registerToken):
+                state.registerToken = registerToken
+//                appCoordinator.changeRoot(to: .signUpView(registToken: registerToken))
+                return .send(.needRegistUser)
                 
             default:
                 return .none
@@ -37,22 +61,11 @@ struct LoginFeature: Reducer {
         }
     }
     
-    private func requestSNSLogin(idToken: String, with type: SNSLoginType) {
+    private func requestSNSLogin(idToken: String, with type: SNSLoginType) async throws {
         let endPoint = APIEndpoints.requestSNSLogin(idToken: idToken, with: type)
-        Task {
-            do {
-                let provider = try await APIProvider().requestSNSLogin(with: endPoint)
-                UDManager.accessToken = provider.accessToken
-                UDManager.refreshToken = provider.refreshToken
-                appCoordinator.changeRoot(to: .mainView)
-            } catch {
-                switch error as? LoginNetworkError {
-                case .needRegist(let registerTokenResponse):
-                    appCoordinator.changeRoot(to: .signUpView(registToken: registerTokenResponse.registerToken))
-                case .none:
-                    return
-                }
-            }
-        }
+        let provider = try await APIProvider().requestSNSLogin(with: endPoint)
+        UDManager.accessToken = provider.accessToken
+        UDManager.refreshToken = provider.refreshToken
+        appCoordinator.changeRoot(to: .mainView)
     }
 }

--- a/weave-iOS/Projects/App/Sources/Login/LoginFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Login/LoginFeature.swift
@@ -47,12 +47,10 @@ struct LoginFeature: Reducer {
                 }
                 
             case .didSuccessedLogin:
-//                appCoordinator.changeRoot(to: .mainView)
                 return .none
                 
             case .fetchRegisterToken(let registerToken):
                 state.registerToken = registerToken
-//                appCoordinator.changeRoot(to: .signUpView(registToken: registerToken))
                 return .send(.needRegistUser)
                 
             default:

--- a/weave-iOS/Projects/App/Sources/SignUp/Feature/SignUpFeature.swift
+++ b/weave-iOS/Projects/App/Sources/SignUp/Feature/SignUpFeature.swift
@@ -152,6 +152,7 @@ struct SignUpFeature: Reducer {
                 return .run { send in
                     UDManager.accessToken = tokens.accessToken
                     UDManager.refreshToken = tokens.refreshToken
+                    try await UserInfo.updateUserInfo()
                     await send.callAsFunction(.didCompleteSignUp)
                 }
                 
@@ -208,7 +209,7 @@ struct SignUpFeature: Reducer {
                 return .none
                 
             case .dismissSignUp:
-                coordinator.changeRoot(to: .loginView)
+//                coordinator.changeRoot(to: .loginView)
                 return .none
                 
             default: return .none

--- a/weave-iOS/Projects/App/Sources/UserInfo/UserInfo.swift
+++ b/weave-iOS/Projects/App/Sources/UserInfo/UserInfo.swift
@@ -6,7 +6,15 @@
 //
 
 import Foundation
+import Services
 
 enum UserInfo {
     static var myInfo: MyUserInfoModel?
+    
+    static func updateUserInfo() async throws {
+        let endPoint = APIEndpoints.getMyUserInfo()
+        let provider = APIProvider()
+        let userInfo = try await provider.request(with: endPoint, showErrorAlert: false)
+        UserInfo.myInfo = userInfo.toDomain
+    }
 }

--- a/weave-iOS/Projects/App/Support/weave-ios-Info.plist
+++ b/weave-iOS/Projects/App/Support/weave-ios-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## 구현사항
- 카카오톡 앱이 없는 경우 웹을 통한 카카오 로그인 지원하도록 변경
- App Feature, Login Feature의 뷰 전환 구조 변경
  - Login Feature 에서의 화면 전환을 상위 리듀서인 App Feature 에서 처리하도록 구현
  - 좀 더 TCA 스러운 전환

## 특이사항
- 추후 다른 리듀서에도 같은 방식의 전화을 적용하고자 함