### PR TITLE
[WEAV-332] 미팅팀 없을 때 필터 재설정 안내 뷰 구현

### DIFF
--- a/weave-iOS/Projects/App/Sources/Chat/View/MatchedMeetingListView.swift
+++ b/weave-iOS/Projects/App/Sources/Chat/View/MatchedMeetingListView.swift
@@ -72,22 +72,12 @@ struct MatchedMeetingListView: View {
     
     @ViewBuilder
     func getEmptyView(handler: @escaping () -> Void) -> some View {
-        VStack(spacing: 10) {
-            Spacer()
-                .frame(height: 200)
-            Text("🙏")
-            Text("미팅을 요청해 보세요!")
-                .font(.pretendard(._600, size: 22))
-            Text("미팅을 요청해야 매칭이 시작돼요!")
-                .font(.pretendard(._500, size: 14))
-                .foregroundStyle(DesignSystem.Colors.gray600)
-            Spacer()
-                .frame(height: 20)
-            WeaveButton(title: "미팅 상대 둘러보기", size: .large) {
-                handler()
-            }
-            .padding(.horizontal, 80)
-        }
+        ListEmptyGuideView(
+            headerTitle: "🙏\n미팅을 요청해 보세요!",
+            subTitle: "미팅을 요청해야 매칭이 시작돼요!",
+            buttonTitle: "미팅 상대 둘러보기",
+            buttonHandler: handler
+        )
     }
 }
 

--- a/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
+++ b/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
@@ -113,21 +113,12 @@ struct MeetingTeamListView: View {
     }
     @ViewBuilder
     func getEmptyView(handler: @escaping () -> Void) -> some View {
-        VStack(spacing: 10) {
-            Spacer()
-                .frame(height: 200)
-            Text("필터를 수정해 보세요!")
-                .font(.pretendard(._600, size: 22))
-            Text("조건에 맞는 미팅 상대팀이 없어요...")
-                .font(.pretendard(._500, size: 14))
-                .foregroundStyle(DesignSystem.Colors.gray600)
-            Spacer()
-                .frame(height: 20)
-            WeaveButton(title: "필터 다시 설정하기", size: .large) {
-                handler()
-            }
-            .padding(.horizontal, 80)
-        }
+        ListEmptyGuideView(
+            headerTitle: "필터를 수정해 보세요!",
+            subTitle: "조건에 맞는 미팅 상대팀이 없어요...",
+            buttonTitle: "필터 다시 설정하기",
+            buttonHandler: handler
+        )
     }
 }
 

--- a/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
+++ b/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
@@ -23,26 +23,31 @@ struct MeetingTeamListView: View {
                 VStack {
                     if !viewStore.isNetworkRequested {
                         ProgressView()
-                    } else if viewStore.isNetworkRequested && viewStore.teamList.isEmpty {
-                        // 미팅팀이 없을 때
-                        EmptyView()
                     } else {
                         ScrollView {
-                            LazyVGrid(columns: [column], spacing: 16, content: {
-                                ForEach(viewStore.teamList, id: \.self) { team in
-                                    MeetingListItemView(teamModel: team)
-                                        .onTapGesture {
-                                            viewStore.send(.didTappedTeamView(id: team.id))
-                                        }
+                            // 미팅팀이 없을 때
+                            if viewStore.teamList.isEmpty {
+                                getEmptyView {
+                                    viewStore.send(.didTappedFilterIcon)
                                 }
-                                if !viewStore.teamList.isEmpty && viewStore.nextCallId != nil {
-                                    ProgressView()
-                                        .onAppear {
-                                            viewStore.send(.requestMeetingTeamListNextPage)
-                                        }
-                                }
-                            })
-                            .padding(.top, 20)
+                            } else {
+                                // 미팅팀 존재
+                                LazyVGrid(columns: [column], spacing: 16, content: {
+                                    ForEach(viewStore.teamList, id: \.self) { team in
+                                        MeetingListItemView(teamModel: team)
+                                            .onTapGesture {
+                                                viewStore.send(.didTappedTeamView(id: team.id))
+                                            }
+                                    }
+                                    if !viewStore.teamList.isEmpty && viewStore.nextCallId != nil {
+                                        ProgressView()
+                                            .onAppear {
+                                                viewStore.send(.requestMeetingTeamListNextPage)
+                                            }
+                                    }
+                                })
+                                .padding(.top, 20)
+                            }
                         }
                         .refreshable {
                             viewStore.send(.requestMeetingTeamList)
@@ -104,6 +109,24 @@ struct MeetingTeamListView: View {
                         .presentationDragIndicator(.visible)
                 }
             }
+        }
+    }
+    @ViewBuilder
+    func getEmptyView(handler: @escaping () -> Void) -> some View {
+        VStack(spacing: 10) {
+            Spacer()
+                .frame(height: 200)
+            Text("필터를 수정해 보세요!")
+                .font(.pretendard(._600, size: 22))
+            Text("조건에 맞는 미팅 상대팀이 없어요...")
+                .font(.pretendard(._500, size: 14))
+                .foregroundStyle(DesignSystem.Colors.gray600)
+            Spacer()
+                .frame(height: 20)
+            WeaveButton(title: "필터 다시 설정하기", size: .large) {
+                handler()
+            }
+            .padding(.horizontal, 80)
         }
     }
 }

--- a/weave-iOS/Projects/App/Sources/MyTeam/View/MyTeamView.swift
+++ b/weave-iOS/Projects/App/Sources/MyTeam/View/MyTeamView.swift
@@ -94,21 +94,12 @@ struct MyTeamView: View {
     
     @ViewBuilder
     func getEmptyView(handler: @escaping () -> Void) -> some View {
-        VStack(spacing: 10) {
-            Spacer()
-                .frame(height: 200)
-            Text("내 팀을 만들어 보세요!")
-                .font(.pretendard(._600, size: 22))
-            Text("내 팀이 있어야 미팅 요청을 할 수 있어요.")
-                .font(.pretendard(._500, size: 14))
-                .foregroundStyle(DesignSystem.Colors.gray600)
-            Spacer()
-                .frame(height: 20)
-            WeaveButton(title: "내 팀 만들기", size: .large) {
-                handler()
-            }
-            .padding(.horizontal, 80)
-        }
+        ListEmptyGuideView(
+            headerTitle: "내 팀을 만들어 보세요!",
+            subTitle: "내 팀이 있어야 미팅 요청을 할 수 있어요.",
+            buttonTitle: "내 팀 만들기",
+            buttonHandler: handler
+        )
     }
 }
 

--- a/weave-iOS/Projects/App/Sources/Request/View/RequestListView.swift
+++ b/weave-iOS/Projects/App/Sources/Request/View/RequestListView.swift
@@ -134,21 +134,12 @@ struct RequestListView: View {
     
     @ViewBuilder
     func getEmptyView(handler: @escaping () -> Void) -> some View {
-        VStack(alignment: .center, spacing: 10) {
-            Spacer()
-                .frame(height: 200)
-            Text("미팅을 요청해 보세요!")
-                .font(.pretendard(._600, size: 22))
-            Text("아직 받은 요청이 없어요")
-                .font(.pretendard(._500, size: 14))
-                .foregroundStyle(DesignSystem.Colors.gray600)
-            Spacer()
-                .frame(height: 20)
-            WeaveButton(title: "미팅 상대 둘러보기", size: .large) {
-                handler()
-            }
-            .padding(.horizontal, 80)
-        }
+        ListEmptyGuideView(
+            headerTitle: "미팅을 요청해 보세요!",
+            subTitle: "아직 받은 요청이 없어요",
+            buttonTitle: "미팅 상대 둘러보기",
+            buttonHandler: handler
+        )
     }
 }
 

--- a/weave-iOS/Projects/DesignSystem/Sources/ListEmptyGuideView/ListEmptyGuideView.swift
+++ b/weave-iOS/Projects/DesignSystem/Sources/ListEmptyGuideView/ListEmptyGuideView.swift
@@ -1,0 +1,53 @@
+//
+//  ListEmptyGuideView.swift
+//  DesignSystem
+//
+//  Created by Jisu Kim on 4/16/24.
+//
+
+import SwiftUI
+
+public struct ListEmptyGuideView: View {
+    
+    let headerTitle: String
+    let subTitle: String?
+    let buttonTitle: String?
+    var buttonHandler: (() -> Void)?
+    
+    public init(
+        headerTitle: String,
+        subTitle: String? = nil,
+        buttonTitle: String? = nil,
+        buttonHandler: (() -> Void)? = nil
+    ) {
+        self.headerTitle = headerTitle
+        self.subTitle = subTitle
+        self.buttonTitle = buttonTitle
+        self.buttonHandler = buttonHandler
+    }
+    
+    
+    public var body: some View {
+        VStack(spacing: 10) {
+            Spacer()
+                .frame(height: 200)
+            Text(headerTitle)
+                .font(.pretendard(._600, size: 22))
+                .multilineTextAlignment(.center)
+                .lineSpacing(5)
+            if let subTitle {
+                Text(subTitle)
+                    .font(.pretendard(._500, size: 14))
+                    .foregroundStyle(DesignSystem.Colors.gray600)
+            }
+            if let buttonTitle {
+                Spacer()
+                    .frame(height: 20)
+                WeaveButton(title: buttonTitle, size: .large) {
+                    buttonHandler?()
+                }
+                .padding(.horizontal, 80)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 구현사항
- 홈 탭 - 미팅팀 리스트가 빈 경우 필터 재설정 안내 문구 및 버튼을 추가했어요
- ListEmptyGuideView 를 생성해 앱 내 모든 리스트에서 공통으로 사용하도록 수정했어요

## 스크린샷(선택)
|필터 재설정 안내 문구|
|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/59bde929-9337-427a-a216-cbc7b32ac64e" width="400">|