### PR TITLE
[Fix] UserInfo 요청 처리 및 대학교 인증 뷰 Validation 추가

### DIFF
--- a/weave-iOS/Projects/App/Sources/AppView/AppViewFeature.swift
+++ b/weave-iOS/Projects/App/Sources/AppView/AppViewFeature.swift
@@ -69,7 +69,10 @@ struct AppViewFeature: Reducer {
                 
             // 로그인 성공
             case .loginAction(.didSuccessedLogin):
-                return .send(.changeRoot(.mainView), animation: .default)
+                return .run { send in
+                    try await UserInfo.updateUserInfo()
+                    await send.callAsFunction(.changeRoot(.mainView), animation: .default)
+                }
                 
             // 회원가입 필요
             case .loginAction(.needRegistUser):

--- a/weave-iOS/Projects/App/Sources/Login/LoginFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Login/LoginFeature.swift
@@ -35,7 +35,6 @@ struct LoginFeature: Reducer {
             case .didTappedLoginButton(let idToken, let type):
                 return .run { send in
                     try await requestSNSLogin(idToken: idToken, with: type)
-                    try await UserInfo.updateUserInfo()
                     await send.callAsFunction(.didSuccessedLogin)
                 } catch: { error, send in
                     switch error as? LoginNetworkError {

--- a/weave-iOS/Projects/App/Sources/Navigation/AppTabViewFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/AppTabViewFeature.swift
@@ -54,7 +54,9 @@ struct AppTabViewFeature: Reducer {
             switch action {
             case .onAppear:
                 if UserInfo.myInfo == nil {
-                    return .send(.myPage(.didTappedSubViews(view: .emailVerification)))
+                    return .run { send in
+                        try await UserInfo.updateUserInfo()
+                    }
                 }
                 return .none
                 


### PR DESCRIPTION
## 구현사항
- UserInfo 없이 TabView가 열리던 이슈 수정
- TabView의 onAppear에서 userInfo가 없는 경우 이메일 인증 뷰를 여는 코드 제거
- 이메일 인증 뷰 접근시 UserInfo 체크 후 열도록 수정