### PR TITLE
[WEAV-339] 팀 나가기 / 팀 초대 기능 보완

### DIFF
--- a/weave-iOS/Projects/App/Sources/MyTeam/Feature/MyTeamFeature.swift
+++ b/weave-iOS/Projects/App/Sources/MyTeam/Feature/MyTeamFeature.swift
@@ -39,6 +39,7 @@ struct MyTeamFeature: Reducer {
         case fetchInviteLink(dto: MyTeamInviteResponseDTO)
       
         case requestDeleteTeam(teamId: String)
+        case requestLeaveTeam(teamId: String)
         
         case destination(PresentationAction<Destination.Action>)
         // bind
@@ -111,9 +112,16 @@ struct MyTeamFeature: Reducer {
                 return .none
                 
             case .requestDeleteTeam(let teamId):
-                print(teamId)
                 return .run { send in
                     try await requestDeleteTeamById(teamId: teamId)
+                    await send.callAsFunction(.requestMyTeamList)
+                } catch: { error, send in
+                    print(error)
+                }
+                
+            case .requestLeaveTeam(let teamId):
+                return .run { send in
+                    try await requestLeaveTeam(teamId: teamId)
                     await send.callAsFunction(.requestMyTeamList)
                 } catch: { error, send in
                     print(error)
@@ -153,6 +161,12 @@ struct MyTeamFeature: Reducer {
     
     func requestDeleteTeamById(teamId: String) async throws {
         let endPoint = APIEndpoints.deleteMyTeam(teamId: teamId)
+        let provider = APIProvider()
+        try await provider.requestWithNoResponse(with: endPoint)
+    }
+    
+    func requestLeaveTeam(teamId: String) async throws {
+        let endPoint = APIEndpoints.leaveTeam(teamId: teamId)
         let provider = APIProvider()
         try await provider.requestWithNoResponse(with: endPoint)
     }

--- a/weave-iOS/Projects/App/Sources/MyTeam/Model/Network/MyTeamDeleteRequestDTO.swift
+++ b/weave-iOS/Projects/App/Sources/MyTeam/Model/Network/MyTeamDeleteRequestDTO.swift
@@ -10,9 +10,19 @@ import Services
 import CoreKit
 
 extension APIEndpoints {
-    static func deleteMyTeam(teamId: String) -> EndPoint<MyTeamListResponseDTO> {
+    static func deleteMyTeam(teamId: String) -> EndPoint<EmptyResponse> {
         return EndPoint(
             path: "api/meeting-teams/\(teamId)",
+            method: .delete,
+            headers: [
+                "Authorization": "Bearer \(UDManager.accessToken)"
+            ]
+        )
+    }
+    
+    static func leaveTeam(teamId: String) -> EndPoint<EmptyResponse> {
+        return EndPoint(
+            path: "api/meeting-teams/\(teamId)/members/me",
             method: .delete,
             headers: [
                 "Authorization": "Bearer \(UDManager.accessToken)"

--- a/weave-iOS/Projects/App/Sources/MyTeam/View/MyTeamView.swift
+++ b/weave-iOS/Projects/App/Sources/MyTeam/View/MyTeamView.swift
@@ -212,7 +212,7 @@ fileprivate struct MyTeamItemView: View {
             .weaveAlert(
                 isPresented: $isShowDeleteConfirmAlert,
                 title: "\(teamModel.teamIntroduce)팀을\n삭제하시겠어요?",
-                message: isTeamCompleted ? "팀을 삭제하시면 진행중인 미팅 요청과 매칭이 자동 취소돼요!" : nil,
+                message: isTeamCompleted ? "지금 팀을 나가시면 팀이 삭제되고 모든 미팅 요청과 매칭이 자동 취소돼요!" : nil,
                 primaryButtonTitle: "삭제할래요",
                 primaryButtonColor: DesignSystem.Colors.notificationRed,
                 secondaryButtonTitle: "아니요",

--- a/weave-iOS/Projects/App/Sources/MyTeam/View/MyTeamView.swift
+++ b/weave-iOS/Projects/App/Sources/MyTeam/View/MyTeamView.swift
@@ -117,6 +117,7 @@ fileprivate struct MyTeamItemView: View {
     let teamModel: MyTeamItemModel
     @State var isShowTeamEditSheet = false
     @State var isShowDeleteConfirmAlert = false
+    @State var isShowLeaveConfirmAlert = false
     
     var sortedTeamMember: [MyTeamMemberModel] {
         return teamModel.memberInfos.sorted { $0.role.sortValue < $1.role.sortValue }
@@ -149,12 +150,10 @@ fileprivate struct MyTeamItemView: View {
                     )
                     locationView(location: teamModel.location)
                     Spacer()
-                    if isMyHostTeam {
-                        DesignSystem.Icons.menu
-                            .onTapGesture {
-                                isShowTeamEditSheet.toggle()
-                            }
-                    }
+                    DesignSystem.Icons.menu
+                        .onTapGesture {
+                            isShowTeamEditSheet.toggle()
+                        }
                 }
                 
                 HStack(alignment: .top) {
@@ -185,14 +184,31 @@ fileprivate struct MyTeamItemView: View {
                 }
             }
             .confirmationDialog("", isPresented: $isShowTeamEditSheet) {
-                Button("내 팀 수정하기") {
-                    viewStore.send(.didTappedModifyMyTeam(team: teamModel))
-                }
-                Button("삭제하기", role: .destructive) {
-                    isShowDeleteConfirmAlert.toggle()
+                if isMyHostTeam {
+                    Button("내 팀 수정하기") {
+                        viewStore.send(.didTappedModifyMyTeam(team: teamModel))
+                    }
+                    Button("삭제하기", role: .destructive) {
+                        isShowDeleteConfirmAlert.toggle()
+                    }
+                } else {
+                    Button("나가기", role: .destructive) {
+                        isShowLeaveConfirmAlert.toggle()
+                    }
                 }
                 Button("닫기", role: .cancel) {}
             }
+            .weaveAlert(
+                isPresented: $isShowLeaveConfirmAlert,
+                title: "\(teamModel.teamIntroduce)팀을\n나가시겠어요?",
+                message: isTeamCompleted ? "팀을 나가시면 진행중인 미팅 요청과 매칭이 자동 취소돼요!" : nil,
+                primaryButtonTitle: "나갈래요",
+                primaryButtonColor: DesignSystem.Colors.notificationRed,
+                secondaryButtonTitle: "아니요",
+                primaryAction: {
+                    viewStore.send(.requestLeaveTeam(teamId: teamModel.id))
+                }
+            )
             .weaveAlert(
                 isPresented: $isShowDeleteConfirmAlert,
                 title: "\(teamModel.teamIntroduce)팀을\n삭제하시겠어요?",

--- a/weave-iOS/Projects/App/Sources/Navigation/AppTabViewFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Navigation/AppTabViewFeature.swift
@@ -92,7 +92,7 @@ struct AppTabViewFeature: Reducer {
                 
             case .didSuccessEnterTeam:
                 tabViewCoordinator.changeTab(to: .myTeam)
-                return .none
+                return .send(.myTeamList(.requestMyTeamList))
                 
             case .didTappedCancelInvitation:
                 state.invitedTeamInfo = nil


### PR DESCRIPTION
## 구현사항
- 팀에 초대받아 참여 완료 이후, 팀 리스트 탭으로 이동, 리스트 refresh 추가
- 팀에 초대받은 유저인 경우 팀 나가기 기능 추가

## 스크린샷(선택)
|팀 나가기|
|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/71a053f6-2d40-4b6b-8182-f7a198d14bbe" width="400">