### PR TITLE
[Feat] 팀 리스트 비었을 때 앱 공유 메시지 기능 추가

### DIFF
--- a/weave-iOS/Projects/App/Sources/Constant/AppConstant.swift
+++ b/weave-iOS/Projects/App/Sources/Constant/AppConstant.swift
@@ -1,0 +1,24 @@
+//
+//  AppConstant.swift
+//  Weave-ios
+//
+//  Created by Jisu Kim on 4/21/24.
+//
+
+import Foundation
+
+enum AppConstant {
+    static let weaveShareMessage = """
+    🌟 새로운 만남의 시작, WEAVE(위브)로 여러분을 초대합니다! 🌟
+
+    ✅️위브만의 특별한 매력
+     안전하고 믿을 수 있는 공간: 대학 이메일 인증으로 진짜 대학생만 만나세요!
+     부담 없는 첫 만남: 프로필 사진은 매칭 후 공개! 귀여운 캐릭터로 자신을 표현해보세요!
+     원하는 대상만 골라서: 미팅 상대의 조건을 제한하고 원하는 상대를 찾아보세요!
+
+    🚀새로운 친구와의 만남을 위해 WEAVE를 선택하세요! 함께 특별한 순간을 만들어보세요! 🚀
+
+    앱스토어 다운로드 : https://apps.apple.com/kr/app/weave-위브/id6477753039
+    플레이스토어 다운로드: https://play.google.com/store/apps/details?id=com.studentcenter.weave
+    """
+}

--- a/weave-iOS/Projects/App/Sources/Home/Feature/MeetingTeamListFeature.swift
+++ b/weave-iOS/Projects/App/Sources/Home/Feature/MeetingTeamListFeature.swift
@@ -14,6 +14,7 @@ struct MeetingTeamListFeature: Reducer {
     
     struct State: Equatable {
         @BindingState var teamList = [MeetingTeamModel]()
+        @BindingState var isShowShareWeaveSheet = false
         
         var nextCallId: String?
         var isNetworkRequested = false
@@ -29,6 +30,7 @@ struct MeetingTeamListFeature: Reducer {
         //MARK: UserAction
         case didTappedTeamView(id: String)
         case didTappedFilterIcon
+        case didTappedShareWeaveButton
         
         // destination
         case destination(PresentationAction<Destination.Action>)
@@ -76,6 +78,10 @@ struct MeetingTeamListFeature: Reducer {
               
             case .didTappedFilterIcon:
                 state.destination = .filter(.init(filterModel: state.filterModel))
+                return .none
+                
+            case .didTappedShareWeaveButton:
+                state.isShowShareWeaveSheet = true
                 return .none
                 
             // Filter 선택 완료 이후

--- a/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
+++ b/weave-iOS/Projects/App/Sources/Home/View/MeetingTeamListView.swift
@@ -28,8 +28,20 @@ struct MeetingTeamListView: View {
                             ScrollView {
                                 // 미팅팀이 없을 때
                                 if viewStore.teamList.isEmpty {
-                                    getEmptyView(viewSize: geometry.size) {
-                                        viewStore.send(.didTappedFilterIcon)
+                                    // 필터 미 적용 상태일 때 - WEAVE 공유
+                                    if viewStore.filterModel == MeetingTeamFilterModel() {
+                                        getShareEmptyView(
+                                            viewSize: geometry.size
+                                        ) {
+                                            viewStore.send(.didTappedShareWeaveButton)
+                                        }
+                                    } else {
+                                        // 필터 적용 상태일 때 - 필터 재적용 안내
+                                        getFilterEmptyView(
+                                            viewSize: geometry.size
+                                        ) {
+                                            viewStore.send(.didTappedFilterIcon)
+                                        }
                                     }
                                 } else {
                                     // 미팅팀 존재
@@ -110,15 +122,35 @@ struct MeetingTeamListView: View {
                         .presentationDetents([.fraction(0.8)])
                         .presentationDragIndicator(.visible)
                 }
+                .background(
+                    ActivityView(
+                        isPresented: viewStore.$isShowShareWeaveSheet,
+                        activityItmes: [
+                            AppConstant.weaveShareMessage
+                        ]
+                    )
+                )
             }
         }
     }
+    
     @ViewBuilder
-    func getEmptyView(viewSize: CGSize, handler: @escaping () -> Void) -> some View {
+    func getFilterEmptyView(viewSize: CGSize, handler: @escaping () -> Void) -> some View {
         ListEmptyGuideView(
             headerTitle: "필터를 수정해 보세요!",
             subTitle: "조건에 맞는 미팅 상대팀이 없어요...",
             buttonTitle: "필터 다시 설정하기",
+            viewSize: viewSize,
+            buttonHandler: handler
+        )
+    }
+    
+    @ViewBuilder
+    func getShareEmptyView(viewSize: CGSize, handler: @escaping () -> Void) -> some View {
+        ListEmptyGuideView(
+            headerTitle: "매칭할 수 있는 팀이 없어요 😢",
+            subTitle: "더 많은 친구들이 이용할 수 있도록\n친구들에게 공유해 주세요!",
+            buttonTitle: "WEAVE 공유하기",
             viewSize: viewSize,
             buttonHandler: handler
         )


### PR DESCRIPTION
## 구현사항
- 공개된 팀이 없을 때 앱 공유 메시지 기능 추가 (UIActivity 사용)

## 스크린샷(선택)
|UIActivity|카카오톡 공유|
|:---:|:---:|
|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/e398ff01-a115-4e4e-a144-52f8b65895b1" width="400">|<img src="https://github.com/Student-Center/weave-ios/assets/108998071/e9722e32-508c-43dd-89cf-e03d38100810" width="400">